### PR TITLE
Use setShouldAbortSpawn(true) to avoid unnecessary further attempts

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/spawner/natural/NaturalSpawnerListener.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/natural/NaturalSpawnerListener.java
@@ -25,6 +25,7 @@ public class NaturalSpawnerListener implements Listener {
 
         if (smartSpawner != null) {
             event.setCancelled(true);
+            event.setShouldAbortSpawn(true);
         } else {
             // This is a natural spawner - check if natural spawning is allowed
             if (!plugin.getConfig().getBoolean("natural_spawner.spawn_mobs", true)) {


### PR DESCRIPTION
See: https://jd.papermc.io/paper/1.21.10/com/destroystokyo/paper/event/entity/PreSpawnerSpawnEvent.html and https://jd.papermc.io/paper/1.21.10/com/destroystokyo/paper/event/entity/PreCreatureSpawnEvent.html#setShouldAbortSpawn(boolean)