### PR TITLE
build: stop shading SQLite JDBC - Paper provides it at runtime

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,7 +15,8 @@ dependencies {
 
     shade("com.zaxxer:HikariCP:5.1.0")
     shade("org.mariadb.jdbc:mariadb-java-client:3.3.2")
-    shade("org.xerial:sqlite-jdbc:3.45.1.0")
+    // SQLite JDBC is provided by Paper's runtime classpath - no need to shade
+    compileOnly("org.xerial:sqlite-jdbc:3.45.1.0")
 
     compileOnly("org.geysermc.floodgate:api:2.2.5-SNAPSHOT")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.1.0-SNAPSHOT")


### PR DESCRIPTION
SQLite JDBC (org.xerial:sqlite-jdbc) bundles ~12MB of native binaries for every platform. Paper already includes it on the runtime classpath, so shading it is unnecessary. Changed to compileOnly, reducing jar size by ~12MB.