### PR TITLE
Fix cross-server spawner list showing N/A for last accessed

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/commands/list/ListSubCommand.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/list/ListSubCommand.java
@@ -837,7 +837,8 @@ public class ListSubCommand extends BaseSubCommand {
         placeholders.put("x", String.valueOf(spawner.getLocX()));
         placeholders.put("y", String.valueOf(spawner.getLocY()));
         placeholders.put("z", String.valueOf(spawner.getLocZ()));
-        placeholders.put("last_player", "N/A");
+        String lastPlayer = spawner.getLastInteractedPlayer();
+        placeholders.put("last_player", lastPlayer != null ? lastPlayer : "None");
 
         ItemStack spawnerItem;
 


### PR DESCRIPTION
The cross-server spawner item builder was hardcoding "N/A" for the last_player placeholder instead of using the actual data from CrossServerSpawnerData, which was already correctly loaded from the DB. This allows server admins to see last user: when not on the same server. 