### PR TITLE
Prevent integration with SimpleClaimSystem 2.x.x

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/hooks/IntegrationManager.java
+++ b/core/src/main/java/github/nighter/smartspawner/hooks/IntegrationManager.java
@@ -99,6 +99,10 @@ public class IntegrationManager {
             if (simpleClaimPlugin == null || !simpleClaimPlugin.isEnabled()) {
                 return false;
             }
+            // Prevent SimpleClaimSystem paid version (2.x.x)
+            if (simpleClaimPlugin.getDescription().getVersion().startsWith("2.")) {
+                return false;
+            }
             SimpleClaimSystemAPI_Provider.initialize((SimpleClaimSystem) simpleClaimPlugin);
             return SimpleClaimSystemAPI_Provider.getAPI() != null;
         }, true);


### PR DESCRIPTION
## Description

Prevent integration with SimpleClaimSystem 2.x.x versions.

## Reason

SimpleClaimSystem 2.x.x is a paid version and is not compatible with the current integration (API differences).

## Changes

* Added version check in `IntegrationManager.java`
* Disabled integration for versions starting with "2."

## Notes

* Prevents potential runtime errors or unexpected behavior
