### PR TITLE
Use cached values in ItemSignature

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/main/SpawnerMenuUI.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/main/SpawnerMenuUI.java
@@ -287,7 +287,7 @@ public class SpawnerMenuUI {
         // Create material-to-amount map for quick lookups
         Map<Material, Long> materialAmountMap = new HashMap<>();
         for (Map.Entry<ItemSignature, Long> entry : storedItems.entrySet()) {
-            Material material = entry.getKey().getTemplateRef().getType();
+            Material material = entry.getKey().getMaterial();
             materialAmountMap.merge(material, entry.getValue(), Long::sum);
         }
 
@@ -333,8 +333,7 @@ public class SpawnerMenuUI {
             sortedItems.sort(Comparator.comparing(e -> e.getKey().getMaterialName()));
 
             for (Map.Entry<ItemSignature, Long> entry : sortedItems) {
-                ItemStack templateItem = entry.getKey().getTemplateRef();
-                Material material = templateItem.getType();
+                Material material = entry.getKey().getMaterial();
                 long amount = entry.getValue();
 
                 String materialName = languageManager.getVanillaItemName(material);
@@ -606,7 +605,7 @@ public class SpawnerMenuUI {
     private List<Component> buildLootItemComponents(EntityType entityType, Map<ItemSignature, Long> storedItems) {
         Map<Material, Long> materialAmountMap = new HashMap<>();
         for (Map.Entry<ItemSignature, Long> entry : storedItems.entrySet()) {
-            Material material = entry.getKey().getTemplateRef().getType();
+            Material material = entry.getKey().getMaterial();
             materialAmountMap.merge(material, entry.getValue(), Long::sum);
         }
 
@@ -633,7 +632,7 @@ public class SpawnerMenuUI {
                     new ArrayList<>(storedItems.entrySet());
             sortedItems.sort(Comparator.comparing(e -> e.getKey().getMaterialName()));
             for (Map.Entry<ItemSignature, Long> entry : sortedItems) {
-                Material material = entry.getKey().getTemplateRef().getType();
+                Material material = entry.getKey().getMaterial();
                 long amount = entry.getValue();
                 String formattedAmount = languageManager.formatNumber(amount);
                 components.add(languageManager.buildTranslatableGuiLootLine(

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/sell/SpawnerSellConfirmUI.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/sell/SpawnerSellConfirmUI.java
@@ -203,7 +203,7 @@ public class SpawnerSellConfirmUI {
     private List<Component> buildSellInfoLootComponents(SpawnerData spawner, Map<ItemSignature, Long> storedItems) {
         Map<Material, Long> materialAmountMap = new HashMap<>();
         for (Map.Entry<ItemSignature, Long> entry : storedItems.entrySet()) {
-            Material material = entry.getKey().getTemplateRef().getType();
+            Material material = entry.getKey().getMaterial();
             materialAmountMap.merge(material, entry.getValue(), Long::sum);
         }
 
@@ -230,7 +230,7 @@ public class SpawnerSellConfirmUI {
             List<Map.Entry<ItemSignature, Long>> sortedItems = new ArrayList<>(storedItems.entrySet());
             sortedItems.sort(Comparator.comparing(e -> e.getKey().getMaterialName()));
             for (Map.Entry<ItemSignature, Long> entry : sortedItems) {
-                Material material = entry.getKey().getTemplateRef().getType();
+                Material material = entry.getKey().getMaterial();
                 long amount = entry.getValue();
                 String formattedAmount = languageManager.formatNumber(amount);
                 components.add(languageManager.buildTranslatableGuiLootLine(

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageUI.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageUI.java
@@ -591,7 +591,7 @@ public class SpawnerStorageUI {
             Map<ItemSignature, Long> storedItems) {
         Map<Material, Long> materialAmountMap = new HashMap<>();
         for (Map.Entry<ItemSignature, Long> entry : storedItems.entrySet()) {
-            Material mat = entry.getKey().getTemplateRef().getType();
+            Material mat = entry.getKey().getMaterial();
             materialAmountMap.merge(mat, entry.getValue(), Long::sum);
         }
 
@@ -622,7 +622,7 @@ public class SpawnerStorageUI {
             List<Map.Entry<ItemSignature, Long>> sortedItems = new ArrayList<>(storedItems.entrySet());
             sortedItems.sort(Comparator.comparing(e -> e.getKey().getMaterialName()));
             for (Map.Entry<ItemSignature, Long> entry : sortedItems) {
-                Material mat = entry.getKey().getTemplateRef().getType();
+                Material mat = entry.getKey().getMaterial();
                 long amount = entry.getValue();
                 String formattedAmount = languageManager.formatNumber(amount);
                 components.add(languageManager.buildTranslatableGuiLootLine(

--- a/core/src/main/java/github/nighter/smartspawner/spawner/lootgen/SpawnerLootGenerator.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/lootgen/SpawnerLootGenerator.java
@@ -341,7 +341,7 @@ public class SpawnerLootGenerator {
         return items.entrySet().stream()
                 .mapToInt(entry -> {
                     long amount = entry.getValue();
-                    int maxStackSize = entry.getKey().getTemplateRef().getMaxStackSize();
+                    int maxStackSize = entry.getKey().getMaxStackSize();
                     // Use integer division with ceiling function
                     return (int) ((amount + maxStackSize - 1) / maxStackSize);
                 })

--- a/core/src/main/java/github/nighter/smartspawner/spawner/properties/ItemSignature.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/properties/ItemSignature.java
@@ -77,7 +77,7 @@ public class ItemSignature {
     }
 
     // Non-cloning method for internal use
-    public ItemStack getTemplateRef() {
+    public ItemStack getUnsafeTemplateRef() {
         return template;
     }
 

--- a/core/src/main/java/github/nighter/smartspawner/spawner/properties/ItemSignature.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/properties/ItemSignature.java
@@ -1,6 +1,7 @@
 package github.nighter.smartspawner.spawner.properties;
 
 import lombok.Getter;
+import lombok.experimental.Accessors;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
@@ -13,11 +14,10 @@ public class ItemSignature {
     @Getter private final Material material;
     @Getter private final int maxStackSize;
     @Getter private final int damage;
-    @Getter private final boolean hasItemMeta;
+    @Getter @Accessors(fluent = true) private final boolean hasItemMeta;
 
     public ItemSignature(ItemStack item) {
-        this.template = item.clone();
-        this.template.setAmount(1);
+        this.template = item.asQuantity(1); // Clone with new amount
         this.material = template.getType();
         this.maxStackSize = template.getMaxStackSize();
 

--- a/core/src/main/java/github/nighter/smartspawner/spawner/properties/SpawnerData.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/properties/SpawnerData.java
@@ -565,12 +565,9 @@ public class SpawnerData {
 
         double addedValue = 0.0;
         for (Map.Entry<ItemSignature, Long> entry : itemsAdded.entrySet()) {
-            // Use getTemplateRef() to avoid cloning - we only need to read properties
-            ItemStack template = entry.getKey().getTemplateRef();
-            long amount = entry.getValue();
-            double itemPrice = findItemPrice(template, priceCache);
+            double itemPrice = findItemPrice(entry.getKey(), priceCache);
             if (itemPrice > 0.0) {
-                addedValue += itemPrice * amount;
+                addedValue += itemPrice * entry.getValue();
             }
         }
 
@@ -599,12 +596,9 @@ public class SpawnerData {
 
         double removedValue = 0.0;
         for (Map.Entry<ItemSignature, Long> entry : consolidated.entrySet()) {
-            // Use getTemplateRef() to avoid cloning - we only need to read properties
-            ItemStack template = entry.getKey().getTemplateRef();
-            long amount = entry.getValue();
-            double itemPrice = findItemPrice(template, priceCache);
+            double itemPrice = findItemPrice(entry.getKey(), priceCache);
             if (itemPrice > 0.0) {
-                removedValue += itemPrice * amount;
+                removedValue += itemPrice * entry.getValue();
             }
         }
 
@@ -630,12 +624,9 @@ public class SpawnerData {
         double totalValue = 0.0;
 
         for (Map.Entry<ItemSignature, Long> entry : items.entrySet()) {
-            // Use getTemplateRef() to avoid cloning - we only need to read properties
-            ItemStack template = entry.getKey().getTemplateRef();
-            long amount = entry.getValue();
-            double itemPrice = findItemPrice(template, priceCache);
+            double itemPrice = findItemPrice(entry.getKey(), priceCache);
             if (itemPrice > 0.0) {
-                totalValue += itemPrice * amount;
+                totalValue += itemPrice * entry.getValue();
             }
         }
 
@@ -678,45 +669,51 @@ public class SpawnerData {
     /**
      * Finds item price using the cache
      */
-    private double findItemPrice(ItemStack item, Map<String, Double> priceCache) {
-        if (item == null || priceCache == null) {
+    private double findItemPrice(ItemSignature itemSignature, Map<String, Double> priceCache) {
+        if (priceCache == null) {
             return 0.0;
         }
-        String itemKey = createItemKey(item);
+        String itemKey = createItemKey(itemSignature);
         Double price = priceCache.get(itemKey);
         return price != null ? price : 0.0;
     }
 
     /**
-     * Creates a unique key for an item (same logic as SpawnerSellManager)
+     * Convenience overload
      */
-    private String createItemKey(ItemStack item) {
-        if (item == null) {
-            return "null";
-        }
+    private String createItemKey(ItemStack itemStack) {
+        if (itemStack == null) return "null";
 
+        return createItemKey(new ItemSignature(itemStack));
+    }
+
+    /**
+     * Creates a unique key for an item (same logic as SpawnerSellManager)
+     * TODO: this feels very wrong ngl
+     */
+    private String createItemKey(ItemSignature itemSignature) {
         StringBuilder key = new StringBuilder();
-        key.append(item.getType().name());
+        key.append(itemSignature.getMaterial().name());
 
         // Add enchantments if present
-        if (item.hasItemMeta() && item.getItemMeta().hasEnchants()) {
+        ItemMeta meta = itemSignature.getTemplateRef().getItemMeta(); // Read-only
+        if (itemSignature.hasItemMeta() && meta.hasEnchants()) {
             key.append("_enchants:");
-            item.getItemMeta().getEnchants().entrySet().stream()
+            meta.getEnchants().entrySet().stream()
                     .sorted(java.util.Map.Entry.comparingByKey(java.util.Comparator.comparing(enchantment -> enchantment.getKey().toString())))
                     .forEach(entry -> key.append(entry.getKey().getKey()).append(":").append(entry.getValue()).append(","));
         }
 
         // Add custom model data if present
-        if (item.hasItemMeta()) {
-            ItemMeta meta = item.getItemMeta();
+        if (itemSignature.hasItemMeta()) {
             if (VersionInitializer.hasCustomModelData(meta)) {
                 key.append("_cmd:").append(VersionInitializer.getCustomModelDataString(meta));
             }
         }
 
         // Add display name if present
-        if (item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
-            key.append("_name:").append(item.getItemMeta().displayName());
+        if (itemSignature.hasItemMeta() && meta.hasDisplayName()) {
+            key.append("_name:").append(meta.displayName());
         }
 
         return key.toString();

--- a/core/src/main/java/github/nighter/smartspawner/spawner/properties/SpawnerData.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/properties/SpawnerData.java
@@ -696,7 +696,7 @@ public class SpawnerData {
         key.append(itemSignature.getMaterial().name());
 
         // Add enchantments if present
-        ItemMeta meta = itemSignature.getTemplateRef().getItemMeta(); // Read-only
+        ItemMeta meta = itemSignature.getUnsafeTemplateRef().getItemMeta(); // Read-only
         if (itemSignature.hasItemMeta() && meta.hasEnchants()) {
             key.append("_enchants:");
             meta.getEnchants().entrySet().stream()

--- a/core/src/main/java/github/nighter/smartspawner/spawner/properties/VirtualInventory.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/properties/VirtualInventory.java
@@ -130,8 +130,8 @@ public class VirtualInventory {
             if (preferredSortMaterial != null) {
                 sortedEntriesCache.sort((e1, e2) -> {
                     // Use getTemplateRef() to avoid cloning - we only need to read the type
-                    boolean e1Preferred = e1.getKey().getTemplateRef().getType() == preferredSortMaterial;
-                    boolean e2Preferred = e2.getKey().getTemplateRef().getType() == preferredSortMaterial;
+                    boolean e1Preferred = e1.getKey().getMaterial() == preferredSortMaterial;
+                    boolean e2Preferred = e2.getKey().getMaterial() == preferredSortMaterial;
 
                     if (e1Preferred && !e2Preferred) return -1;
                     if (!e1Preferred && e2Preferred) return 1;
@@ -153,15 +153,14 @@ public class VirtualInventory {
 
             ItemSignature sig = entry.getKey();
             long totalAmount = entry.getValue();
-            ItemStack templateItem = sig.getTemplateRef();
-            int maxStackSize = templateItem.getMaxStackSize();
+            int maxStackSize = sig.getMaxStackSize();
 
             // Create as many stacks as needed for this item type
             while (totalAmount > 0 && currentSlot < maxSlots) {
                 int stackSize = (int) Math.min(totalAmount, maxStackSize);
 
                 // Create the display item only once per slot
-                ItemStack displayItem = templateItem.clone();
+                ItemStack displayItem = sig.getTemplate();
                 displayItem.setAmount(stackSize);
 
                 // Store in cache
@@ -203,7 +202,7 @@ public class VirtualInventory {
             int estimatedSlots = 0;
             for (Map.Entry<ItemSignature, Long> entry : consolidatedItems.entrySet()) {
                 long amount = entry.getValue();
-                int maxStackSize = entry.getKey().getTemplateRef().getMaxStackSize();
+                int maxStackSize = entry.getKey().getMaxStackSize();
                 estimatedSlots += (int) Math.ceil((double) amount / maxStackSize);
                 if (estimatedSlots >= maxSlots) {
                     return maxSlots; // Cap at max slots
@@ -250,8 +249,8 @@ public class VirtualInventory {
             this.sortedEntriesCache = consolidatedItems.entrySet().stream()
                 .sorted((e1, e2) -> {
                     // Use getTemplateRef() to avoid cloning - we only need to read the type
-                    boolean e1Preferred = e1.getKey().getTemplateRef().getType() == preferredMaterial;
-                    boolean e2Preferred = e2.getKey().getTemplateRef().getType() == preferredMaterial;
+                    boolean e1Preferred = e1.getKey().getMaterial() == preferredMaterial;
+                    boolean e2Preferred = e2.getKey().getMaterial() == preferredMaterial;
 
                     if (e1Preferred && !e2Preferred) return -1;
                     if (!e1Preferred && e2Preferred) return 1;

--- a/core/src/main/java/github/nighter/smartspawner/spawner/sell/SpawnerSellManager.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/sell/SpawnerSellManager.java
@@ -188,9 +188,9 @@ public class SpawnerSellManager {
         ArrayList<ItemStack> itemsToRemove = new ArrayList<>();
 
         for (Map.Entry<ItemSignature, Long> entry : consolidatedItems.entrySet()) {
-            ItemStack templateRef = entry.getKey().getTemplateRef();
+            ItemSignature signature = entry.getKey();
             long amount = entry.getValue();
-            int maxStackSize = templateRef.getMaxStackSize();
+            int maxStackSize = signature.getMaxStackSize();
 
             totalItemsSold += amount;
 
@@ -199,7 +199,7 @@ public class SpawnerSellManager {
 
             long remaining = amount;
             while (remaining > 0) {
-                ItemStack stack = templateRef.clone();
+                ItemStack stack = signature.getTemplate();
                 stack.setAmount((int) Math.min(remaining, maxStackSize));
                 itemsToRemove.add(stack);
                 remaining -= stack.getAmount();

--- a/core/src/main/java/github/nighter/smartspawner/spawner/utils/ItemStackSerializer.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/utils/ItemStackSerializer.java
@@ -43,12 +43,12 @@ public class ItemStackSerializer {
 
         for (Map.Entry<ItemSignature, Long> entry : items.entrySet()) {
             // Use getTemplateRef() to avoid cloning - we only need to read properties
-            ItemStack template = entry.getKey().getTemplateRef();
-            Material material = template.getType();
+            ItemSignature signature = entry.getKey();
+            Material material = signature.getMaterial();
             ItemGroup group = groupedItems.computeIfAbsent(material, ItemGroup::new);
 
             if (material == Material.TIPPED_ARROW) {
-                PotionMeta meta = (PotionMeta) template.getItemMeta();
+                PotionMeta meta = (PotionMeta) signature.getTemplateRef().getItemMeta(); // Read-only
                 if (meta != null && meta.getBasePotionType() != null) {
                     group.addPotionArrow(meta.getBasePotionType(), entry.getValue().intValue());
                 } else {
@@ -57,7 +57,7 @@ public class ItemStackSerializer {
                 }
             } else if (isDestructibleItem(material)) {
                 // Use modern damage system instead of durability
-                int damage = getDamageValue(template);
+                int damage = signature.getDamage();
                 group.addItem(damage, entry.getValue().intValue());
             } else {
                 // For non-destructible items, always use damage 0
@@ -155,16 +155,6 @@ public class ItemStackSerializer {
             }
         }
         return result;
-    }
-
-    /**
-     * Get damage value from ItemStack using modern API
-     */
-    private static int getDamageValue(ItemStack item) {
-        if (item.getItemMeta() instanceof Damageable damageable) {
-            return damageable.getDamage();
-        }
-        return 0;
     }
 
     /**

--- a/core/src/main/java/github/nighter/smartspawner/spawner/utils/ItemStackSerializer.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/utils/ItemStackSerializer.java
@@ -48,7 +48,7 @@ public class ItemStackSerializer {
             ItemGroup group = groupedItems.computeIfAbsent(material, ItemGroup::new);
 
             if (material == Material.TIPPED_ARROW) {
-                PotionMeta meta = (PotionMeta) signature.getTemplateRef().getItemMeta(); // Read-only
+                PotionMeta meta = (PotionMeta) signature.getUnsafeTemplateRef().getItemMeta(); // Read-only
                 if (meta != null && meta.getBasePotionType() != null) {
                     group.addPotionArrow(meta.getBasePotionType(), entry.getValue().intValue());
                 } else {


### PR DESCRIPTION
Refactor `ItemSignature` hot paths and reduce repeated `ItemStack` access.

* Use cached properties inside `ItemSignature`
* Centralize cloning through `getTemplate()`
* Rename `getTemplateRef()` to `getUnsafeTemplateRef()`

Behavior should remain unchanged.

**Note**: I'm trying to split PR #235 into multiple smaller and specific PRs.