### PR TITLE
feat: Add ExcellentShop integration + /ss priceanalysis command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ allprojects {
     version = "1.6.8"
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven {
             name = "papermc-repo"
@@ -49,6 +50,9 @@ allprojects {
         maven {
             name = "nightexpress-releases"
             url = uri("https://repo.nightexpressdev.com/releases")
+            content {
+                includeGroupByRegex("su\\.nightexpress.*")
+            }
         }
         maven {
             name = "iridiumdevelopment"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
     compileOnly("su.nightexpress.excellenteconomy:ExcellentEconomy:2.8.0")
     compileOnly("su.nightexpress.nightcore:main:2.15.3")
+    compileOnly("su.nightexpress.excellentshop:api:5.1.1")
+    compileOnly("su.nightexpress.excellentshop:Core:5.1.1")
     compileOnly("com.github.Gypopo:EconomyShopGUI-API:1.10.0")
     compileOnly("world.bentobox:bentobox:3.16.2")
     compileOnly("dev.aurelium:auraskills-api-bukkit:2.3.12")

--- a/core/src/main/java/github/nighter/smartspawner/commands/MainCommand.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/MainCommand.java
@@ -9,6 +9,7 @@ import github.nighter.smartspawner.commands.hologram.HologramSubCommand;
 import github.nighter.smartspawner.commands.list.ListSubCommand;
 import github.nighter.smartspawner.commands.near.NearSubCommand;
 import github.nighter.smartspawner.commands.prices.PricesSubCommand;
+import github.nighter.smartspawner.commands.priceanalysis.PriceAnalysisSubCommand;
 import github.nighter.smartspawner.commands.reload.ReloadSubCommand;
 import github.nighter.smartspawner.commands.set.SetSubCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
@@ -36,7 +37,8 @@ public class MainCommand {
                 new PricesSubCommand(plugin),
                 new ClearSubCommand(plugin),
                 new NearSubCommand(plugin, plugin.getSpawnerHighlightManager()),
-                new SetSubCommand(plugin)
+                new SetSubCommand(plugin),
+                new PriceAnalysisSubCommand(plugin)
         );
     }
 

--- a/core/src/main/java/github/nighter/smartspawner/commands/priceanalysis/PriceAnalysisSubCommand.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/priceanalysis/PriceAnalysisSubCommand.java
@@ -205,10 +205,19 @@ public class PriceAnalysisSubCommand extends BaseSubCommand {
         if (notConfigured > 0) {
             sender.sendMessage("");
             sender.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC
-                    + "⚠ " + notConfigured + " item(s) have no price. Add them to item_prices.yml or your shop.");
+                    + "⚠ " + notConfigured + " item(s) have no price. " + getMissingPriceHint(priceManager.getPriceSourceMode()));
         }
 
         return 1;
+    }
+
+    private String getMissingPriceHint(PriceSourceMode mode) {
+        return switch (mode) {
+            case SHOP_ONLY       -> "Add them to your shop plugin — custom prices are ignored in SHOP_ONLY mode.";
+            case CUSTOM_ONLY     -> "Add them to item_prices.yml — shop prices are ignored in CUSTOM_ONLY mode.";
+            case SHOP_PRIORITY   -> "Add them to your shop plugin (preferred) or item_prices.yml as fallback.";
+            case CUSTOM_PRIORITY -> "Add them to item_prices.yml (preferred) or your shop plugin as fallback.";
+        };
     }
 
     private PriceSource resolveSource(ItemPriceManager pm, Material material) {

--- a/core/src/main/java/github/nighter/smartspawner/commands/priceanalysis/PriceAnalysisSubCommand.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/priceanalysis/PriceAnalysisSubCommand.java
@@ -1,6 +1,9 @@
 package github.nighter.smartspawner.commands.priceanalysis;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import github.nighter.smartspawner.SmartSpawner;
 import github.nighter.smartspawner.commands.BaseSubCommand;
 import github.nighter.smartspawner.hooks.economy.ItemPriceManager;
@@ -9,6 +12,7 @@ import github.nighter.smartspawner.spawner.data.SpawnerManager;
 import github.nighter.smartspawner.spawner.lootgen.loot.LootItem;
 import github.nighter.smartspawner.spawner.properties.SpawnerData;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
@@ -16,44 +20,98 @@ import org.bukkit.command.CommandSender;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @NullMarked
 public class PriceAnalysisSubCommand extends BaseSubCommand {
+
+    private static final String ARG_SPAWNER_TYPE = "spawnerType";
 
     public PriceAnalysisSubCommand(SmartSpawner plugin) {
         super(plugin);
     }
 
     @Override
-    public String getName() {
-        return "priceanalysis";
-    }
+    public String getName() { return "priceanalysis"; }
 
     @Override
-    public String getPermission() {
-        return "smartspawner.command.priceanalysis";
-    }
+    public String getPermission() { return "smartspawner.command.priceanalysis"; }
 
     @Override
-    public String getDescription() {
-        return "Show price analysis for all sellable items across all spawners";
+    public String getDescription() { return "Show price analysis for sellable items across spawners"; }
+
+    // Override build() to wire optional spawner type argument with tab completion
+    @Override
+    public LiteralArgumentBuilder<CommandSourceStack> build() {
+        LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal(getName());
+        builder.requires(source -> hasPermission(source.getSender()));
+
+        // /ss priceanalysis — all spawners
+        builder.executes(context -> {
+            logCommandExecution(context);
+            return runAnalysis(context, null);
+        });
+
+        // /ss priceanalysis <spawnerType> — specific spawner type
+        builder.then(Commands.argument(ARG_SPAWNER_TYPE, StringArgumentType.word())
+                .suggests(createSpawnerTypeSuggestions())
+                .executes(context -> {
+                    logCommandExecution(context);
+                    String arg = StringArgumentType.getString(context, ARG_SPAWNER_TYPE);
+                    return runAnalysis(context, arg.toUpperCase());
+                })
+        );
+
+        return builder;
     }
 
     @Override
     public int execute(CommandContext<CommandSourceStack> context) {
-        CommandSender sender = context.getSource().getSender();
+        return runAnalysis(context, null);
+    }
 
+    /**
+     * Suggests entity types that actually have spawners on this server.
+     */
+    private SuggestionProvider<CommandSourceStack> createSpawnerTypeSuggestions() {
+        return (context, builder) -> {
+            String input = builder.getRemaining().toLowerCase();
+            getActiveSpawnerTypes().stream()
+                    .map(e -> e.name().toLowerCase())
+                    .filter(name -> name.startsWith(input))
+                    .sorted()
+                    .forEach(builder::suggest);
+            return builder.buildFuture();
+        };
+    }
+
+    /**
+     * Returns the set of EntityTypes that have at least one spawner loaded.
+     */
+    private Set<EntityType> getActiveSpawnerTypes() {
+        Set<EntityType> types = new LinkedHashSet<>();
+        for (SpawnerData spawner : plugin.getSpawnerManager().getAllSpawners()) {
+            if (!spawner.getValidLootItems().isEmpty()) {
+                types.add(spawner.getEntityType());
+            }
+        }
+        return types;
+    }
+
+    private int runAnalysis(CommandContext<CommandSourceStack> context, String filterType) {
+        CommandSender sender = context.getSource().getSender();
         ItemPriceManager priceManager = plugin.getItemPriceManager();
         SpawnerManager spawnerManager = plugin.getSpawnerManager();
 
-        // Collect unique materials across all spawners, grouped by spawner type
-        // Map: EntityType -> Set<Material>
+        // Build map: EntityType -> Set<Material>
         Map<EntityType, Set<Material>> materialsByType = new LinkedHashMap<>();
-
         for (SpawnerData spawner : spawnerManager.getAllSpawners()) {
             EntityType type = spawner.getEntityType();
-            List<LootItem> lootItems = spawner.getValidLootItems();
 
+            // Filter to specific type if argument provided
+            if (filterType != null && !type.name().equalsIgnoreCase(filterType)) continue;
+
+            List<LootItem> lootItems = spawner.getValidLootItems();
             if (lootItems.isEmpty()) continue;
 
             Set<Material> materials = materialsByType.computeIfAbsent(type, k -> new LinkedHashSet<>());
@@ -63,32 +121,38 @@ public class PriceAnalysisSubCommand extends BaseSubCommand {
         }
 
         if (materialsByType.isEmpty()) {
-            sender.sendMessage(ChatColor.RED + "No spawners found or no sellable items configured.");
+            if (filterType != null) {
+                sender.sendMessage(ChatColor.RED + "No spawners found for type: " + ChatColor.YELLOW + filterType
+                        + ChatColor.RED + ". Use /ss priceanalysis for the full list.");
+            } else {
+                sender.sendMessage(ChatColor.RED + "No spawners found or no sellable items configured.");
+            }
             return 0;
         }
 
-        // --- Header ---
-        sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "════ SmartSpawner Price Analysis ════");
+        // Header
+        String scope = filterType != null
+                ? formatEntityName(filterType)
+                : "All Spawners";
+        sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "════ Price Analysis: " + scope + " ════");
         sender.sendMessage(ChatColor.GRAY + "Mode: " + ChatColor.YELLOW + priceManager.getPriceSourceMode().name()
                 + ChatColor.GRAY + "  Source: " + ChatColor.AQUA + getActiveSourceLabel(priceManager));
         sender.sendMessage("");
 
-        int totalItems = 0;
-        int shopPriced = 0;
-        int customPriced = 0;
-        int notConfigured = 0;
+        int totalItems = 0, shopPriced = 0, customPriced = 0, notConfigured = 0;
 
-        // --- Per spawner type breakdown ---
         for (Map.Entry<EntityType, Set<Material>> entry : materialsByType.entrySet()) {
-            EntityType entityType = entry.getKey();
             Set<Material> materials = entry.getValue();
 
-            sender.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD
-                    + formatEntityName(entityType) + ChatColor.GRAY + " (" + materials.size() + " items)");
+            // Show spawner type header only in "all" mode (single type is already in the title)
+            if (filterType == null) {
+                sender.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD
+                        + formatEntityName(entry.getKey().name())
+                        + ChatColor.GRAY + " (" + materials.size() + " items)");
+            }
 
             for (Material material : materials) {
                 totalItems++;
-
                 double finalPrice = priceManager.getPrice(material);
                 PriceSource source = resolveSource(priceManager, material);
 
@@ -123,18 +187,20 @@ public class PriceAnalysisSubCommand extends BaseSubCommand {
                     }
                 }
 
-                sender.sendMessage(ChatColor.GRAY + "  " + lineColor + formatMaterialName(material)
+                String indent = filterType != null ? "" : "  ";
+                sender.sendMessage(ChatColor.GRAY + indent + lineColor + formatMaterialName(material)
                         + ChatColor.DARK_GRAY + " → " + priceStr + "  " + sourceLabel);
             }
-            sender.sendMessage("");
+            if (filterType == null) sender.sendMessage("");
         }
 
-        // --- Summary ---
+        // Summary
+        sender.sendMessage("");
         sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "════ Summary ════");
-        sender.sendMessage(ChatColor.GRAY + "Total items:      " + ChatColor.WHITE + totalItems);
-        sender.sendMessage(ChatColor.GREEN + "From shop:        " + ChatColor.WHITE + shopPriced);
-        sender.sendMessage(ChatColor.YELLOW + "From custom/fallback: " + ChatColor.WHITE + customPriced);
-        sender.sendMessage(ChatColor.RED + "Not configured:   " + ChatColor.WHITE + notConfigured);
+        sender.sendMessage(ChatColor.GRAY + "Total items:           " + ChatColor.WHITE + totalItems);
+        sender.sendMessage(ChatColor.GREEN + "From shop:             " + ChatColor.WHITE + shopPriced);
+        sender.sendMessage(ChatColor.YELLOW + "From custom/fallback:  " + ChatColor.WHITE + customPriced);
+        sender.sendMessage(ChatColor.RED + "Not configured:        " + ChatColor.WHITE + notConfigured);
 
         if (notConfigured > 0) {
             sender.sendMessage("");
@@ -145,26 +211,22 @@ public class PriceAnalysisSubCommand extends BaseSubCommand {
         return 1;
     }
 
-    /**
-     * Determines exactly which source provided the final price for a material,
-     * respecting the configured price_source_mode.
-     */
     private PriceSource resolveSource(ItemPriceManager pm, Material material) {
         PriceSourceMode mode = pm.getPriceSourceMode();
-        double shopPrice  = pm.getShopPriceFor(material);
+        double shopPrice   = pm.getShopPriceFor(material);
         double customPrice = pm.getCustomPriceFor(material);
 
         return switch (mode) {
-            case SHOP_ONLY -> shopPrice > 0 ? PriceSource.SHOP : PriceSource.NONE;
-            case CUSTOM_ONLY -> customPrice > 0 ? PriceSource.CUSTOM : PriceSource.NONE;
+            case SHOP_ONLY    -> shopPrice   > 0 ? PriceSource.SHOP   : PriceSource.NONE;
+            case CUSTOM_ONLY  -> customPrice > 0 ? PriceSource.CUSTOM : PriceSource.NONE;
             case SHOP_PRIORITY -> {
-                if (shopPrice > 0)   yield PriceSource.SHOP;
+                if (shopPrice   > 0) yield PriceSource.SHOP;
                 if (customPrice > 0) yield PriceSource.FALLBACK;
                 yield PriceSource.NONE;
             }
             case CUSTOM_PRIORITY -> {
                 if (customPrice > 0) yield PriceSource.CUSTOM;
-                if (shopPrice > 0)   yield PriceSource.FALLBACK;
+                if (shopPrice   > 0) yield PriceSource.FALLBACK;
                 yield PriceSource.NONE;
             }
         };
@@ -173,23 +235,26 @@ public class PriceAnalysisSubCommand extends BaseSubCommand {
     private String getActiveSourceLabel(ItemPriceManager pm) {
         boolean hasShop   = pm.getShopIntegrationManager() != null && pm.getShopIntegrationManager().hasActiveProvider();
         boolean hasCustom = pm.customPricesEnabled;
-
         if (hasShop && hasCustom) return "Shop + Custom";
         if (hasShop)   return pm.getShopIntegrationManager().getActiveShopPlugin();
         if (hasCustom) return "Custom prices";
         return "None";
     }
 
-    private String formatEntityName(EntityType type) {
-        return Arrays.stream(type.name().split("_"))
+    private String formatEntityName(String name) {
+        return Arrays.stream(name.split("_"))
                 .map(w -> w.charAt(0) + w.substring(1).toLowerCase())
-                .reduce("", (a, b) -> a.isEmpty() ? b : a + " " + b);
+                .collect(Collectors.joining(" "));
+    }
+
+    private String formatEntityName(EntityType type) {
+        return formatEntityName(type.name());
     }
 
     private String formatMaterialName(Material material) {
         return Arrays.stream(material.name().split("_"))
                 .map(w -> w.charAt(0) + w.substring(1).toLowerCase())
-                .reduce("", (a, b) -> a.isEmpty() ? b : a + " " + b);
+                .collect(Collectors.joining(" "));
     }
 
     private enum PriceSource { SHOP, CUSTOM, FALLBACK, NONE }

--- a/core/src/main/java/github/nighter/smartspawner/commands/priceanalysis/PriceAnalysisSubCommand.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/priceanalysis/PriceAnalysisSubCommand.java
@@ -1,0 +1,196 @@
+package github.nighter.smartspawner.commands.priceanalysis;
+
+import com.mojang.brigadier.context.CommandContext;
+import github.nighter.smartspawner.SmartSpawner;
+import github.nighter.smartspawner.commands.BaseSubCommand;
+import github.nighter.smartspawner.hooks.economy.ItemPriceManager;
+import github.nighter.smartspawner.hooks.economy.ItemPriceManager.PriceSourceMode;
+import github.nighter.smartspawner.spawner.data.SpawnerManager;
+import github.nighter.smartspawner.spawner.lootgen.loot.LootItem;
+import github.nighter.smartspawner.spawner.properties.SpawnerData;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.command.CommandSender;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.*;
+
+@NullMarked
+public class PriceAnalysisSubCommand extends BaseSubCommand {
+
+    public PriceAnalysisSubCommand(SmartSpawner plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public String getName() {
+        return "priceanalysis";
+    }
+
+    @Override
+    public String getPermission() {
+        return "smartspawner.command.priceanalysis";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Show price analysis for all sellable items across all spawners";
+    }
+
+    @Override
+    public int execute(CommandContext<CommandSourceStack> context) {
+        CommandSender sender = context.getSource().getSender();
+
+        ItemPriceManager priceManager = plugin.getItemPriceManager();
+        SpawnerManager spawnerManager = plugin.getSpawnerManager();
+
+        // Collect unique materials across all spawners, grouped by spawner type
+        // Map: EntityType -> Set<Material>
+        Map<EntityType, Set<Material>> materialsByType = new LinkedHashMap<>();
+
+        for (SpawnerData spawner : spawnerManager.getAllSpawners()) {
+            EntityType type = spawner.getEntityType();
+            List<LootItem> lootItems = spawner.getValidLootItems();
+
+            if (lootItems.isEmpty()) continue;
+
+            Set<Material> materials = materialsByType.computeIfAbsent(type, k -> new LinkedHashSet<>());
+            for (LootItem loot : lootItems) {
+                materials.add(loot.material());
+            }
+        }
+
+        if (materialsByType.isEmpty()) {
+            sender.sendMessage(ChatColor.RED + "No spawners found or no sellable items configured.");
+            return 0;
+        }
+
+        // --- Header ---
+        sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "════ SmartSpawner Price Analysis ════");
+        sender.sendMessage(ChatColor.GRAY + "Mode: " + ChatColor.YELLOW + priceManager.getPriceSourceMode().name()
+                + ChatColor.GRAY + "  Source: " + ChatColor.AQUA + getActiveSourceLabel(priceManager));
+        sender.sendMessage("");
+
+        int totalItems = 0;
+        int shopPriced = 0;
+        int customPriced = 0;
+        int notConfigured = 0;
+
+        // --- Per spawner type breakdown ---
+        for (Map.Entry<EntityType, Set<Material>> entry : materialsByType.entrySet()) {
+            EntityType entityType = entry.getKey();
+            Set<Material> materials = entry.getValue();
+
+            sender.sendMessage(ChatColor.AQUA + "" + ChatColor.BOLD
+                    + formatEntityName(entityType) + ChatColor.GRAY + " (" + materials.size() + " items)");
+
+            for (Material material : materials) {
+                totalItems++;
+
+                double finalPrice = priceManager.getPrice(material);
+                PriceSource source = resolveSource(priceManager, material);
+
+                String priceStr;
+                String sourceLabel;
+                ChatColor lineColor;
+
+                switch (source) {
+                    case SHOP -> {
+                        shopPriced++;
+                        lineColor = ChatColor.GREEN;
+                        sourceLabel = ChatColor.GREEN + "[Shop]";
+                        priceStr = ChatColor.WHITE + String.format("$%.2f", finalPrice);
+                    }
+                    case CUSTOM -> {
+                        customPriced++;
+                        lineColor = ChatColor.YELLOW;
+                        sourceLabel = ChatColor.YELLOW + "[Custom]";
+                        priceStr = ChatColor.WHITE + String.format("$%.2f", finalPrice);
+                    }
+                    case FALLBACK -> {
+                        customPriced++;
+                        lineColor = ChatColor.YELLOW;
+                        sourceLabel = ChatColor.YELLOW + "[Fallback]";
+                        priceStr = ChatColor.WHITE + String.format("$%.2f", finalPrice);
+                    }
+                    default -> {
+                        notConfigured++;
+                        lineColor = ChatColor.RED;
+                        sourceLabel = ChatColor.RED + "[Not Configured]";
+                        priceStr = ChatColor.RED + "N/A";
+                    }
+                }
+
+                sender.sendMessage(ChatColor.GRAY + "  " + lineColor + formatMaterialName(material)
+                        + ChatColor.DARK_GRAY + " → " + priceStr + "  " + sourceLabel);
+            }
+            sender.sendMessage("");
+        }
+
+        // --- Summary ---
+        sender.sendMessage(ChatColor.GOLD + "" + ChatColor.BOLD + "════ Summary ════");
+        sender.sendMessage(ChatColor.GRAY + "Total items:      " + ChatColor.WHITE + totalItems);
+        sender.sendMessage(ChatColor.GREEN + "From shop:        " + ChatColor.WHITE + shopPriced);
+        sender.sendMessage(ChatColor.YELLOW + "From custom/fallback: " + ChatColor.WHITE + customPriced);
+        sender.sendMessage(ChatColor.RED + "Not configured:   " + ChatColor.WHITE + notConfigured);
+
+        if (notConfigured > 0) {
+            sender.sendMessage("");
+            sender.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC
+                    + "⚠ " + notConfigured + " item(s) have no price. Add them to item_prices.yml or your shop.");
+        }
+
+        return 1;
+    }
+
+    /**
+     * Determines exactly which source provided the final price for a material,
+     * respecting the configured price_source_mode.
+     */
+    private PriceSource resolveSource(ItemPriceManager pm, Material material) {
+        PriceSourceMode mode = pm.getPriceSourceMode();
+        double shopPrice  = pm.getShopPriceFor(material);
+        double customPrice = pm.getCustomPriceFor(material);
+
+        return switch (mode) {
+            case SHOP_ONLY -> shopPrice > 0 ? PriceSource.SHOP : PriceSource.NONE;
+            case CUSTOM_ONLY -> customPrice > 0 ? PriceSource.CUSTOM : PriceSource.NONE;
+            case SHOP_PRIORITY -> {
+                if (shopPrice > 0)   yield PriceSource.SHOP;
+                if (customPrice > 0) yield PriceSource.FALLBACK;
+                yield PriceSource.NONE;
+            }
+            case CUSTOM_PRIORITY -> {
+                if (customPrice > 0) yield PriceSource.CUSTOM;
+                if (shopPrice > 0)   yield PriceSource.FALLBACK;
+                yield PriceSource.NONE;
+            }
+        };
+    }
+
+    private String getActiveSourceLabel(ItemPriceManager pm) {
+        boolean hasShop   = pm.getShopIntegrationManager() != null && pm.getShopIntegrationManager().hasActiveProvider();
+        boolean hasCustom = pm.customPricesEnabled;
+
+        if (hasShop && hasCustom) return "Shop + Custom";
+        if (hasShop)   return pm.getShopIntegrationManager().getActiveShopPlugin();
+        if (hasCustom) return "Custom prices";
+        return "None";
+    }
+
+    private String formatEntityName(EntityType type) {
+        return Arrays.stream(type.name().split("_"))
+                .map(w -> w.charAt(0) + w.substring(1).toLowerCase())
+                .reduce("", (a, b) -> a.isEmpty() ? b : a + " " + b);
+    }
+
+    private String formatMaterialName(Material material) {
+        return Arrays.stream(material.name().split("_"))
+                .map(w -> w.charAt(0) + w.substring(1).toLowerCase())
+                .reduce("", (a, b) -> a.isEmpty() ? b : a + " " + b);
+    }
+
+    private enum PriceSource { SHOP, CUSTOM, FALLBACK, NONE }
+}

--- a/core/src/main/java/github/nighter/smartspawner/hooks/economy/ItemPriceManager.java
+++ b/core/src/main/java/github/nighter/smartspawner/hooks/economy/ItemPriceManager.java
@@ -143,6 +143,20 @@ public class ItemPriceManager {
         }
     }
 
+    public PriceSourceMode getPriceSourceMode() {
+        return priceSourceMode;
+    }
+
+    /** Raw shop price for this material (0 if unavailable). Used by price analysis. */
+    public double getShopPriceFor(Material material) {
+        return getShopPrice(material);
+    }
+
+    /** Raw custom price for this material (0 if not configured). Used by price analysis. */
+    public double getCustomPriceFor(Material material) {
+        return getCustomPrice(material);
+    }
+
     public double getPrice(Material material) {
         if (material == null || !economyEnabled) return 0.0;
 

--- a/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/ShopIntegrationManager.java
+++ b/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/ShopIntegrationManager.java
@@ -6,6 +6,7 @@ import github.nighter.smartspawner.hooks.economy.shops.providers.economyshopgui.
 import github.nighter.smartspawner.hooks.economy.shops.providers.economyshopgui.ESGUICompatibilityHandler;
 import github.nighter.smartspawner.hooks.economy.shops.providers.shopguiplus.ShopGuiPlusProvider;
 import github.nighter.smartspawner.hooks.economy.shops.providers.shopguiplus.SpawnerHook;
+import github.nighter.smartspawner.hooks.economy.shops.providers.excellentshop.ExcellentShopProvider;
 import github.nighter.smartspawner.hooks.economy.shops.providers.zshop.ZShopProvider;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Material;
@@ -81,6 +82,10 @@ public class ShopIntegrationManager {
         }
 
         // registerProviderIfAvailable("ZShop", () -> new ZShopProvider(plugin));
+
+        if (isPluginAvailable("ExcellentShop")) {
+            registerProviderIfAvailable("ExcellentShop", () -> new ExcellentShopProvider(plugin));
+        }
     }
 
     private boolean tryRegisterSpecificProvider(String providerName) {
@@ -122,6 +127,12 @@ public class ShopIntegrationManager {
                 case "zshop":
                     if (isPluginAvailable("ZShop")) {
                         registerProviderIfAvailable("ZShop", () -> new ZShopProvider(plugin));
+                        return !availableProviders.isEmpty();
+                    }
+                    break;
+                case "excellentshop":
+                    if (isPluginAvailable("ExcellentShop")) {
+                        registerProviderIfAvailable("ExcellentShop", () -> new ExcellentShopProvider(plugin));
                         return !availableProviders.isEmpty();
                     }
                     break;

--- a/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/excellentshop/ExcellentShopProvider.java
+++ b/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/excellentshop/ExcellentShopProvider.java
@@ -36,7 +36,8 @@ public class ExcellentShopProvider implements ShopProvider {
 
             Class.forName("su.nightexpress.excellentshop.ShopAPI");
             Class.forName("su.nightexpress.excellentshop.virtualshop.VirtualShopModule");
-            return ShopAPI.isInitialized();
+            // Plugin is enabled — API will be initialized by the time we need it
+            return true;
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
             plugin.debug("ExcellentShop API not found: " + e.getMessage());
         } catch (Exception e) {

--- a/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/excellentshop/ExcellentShopProvider.java
+++ b/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/excellentshop/ExcellentShopProvider.java
@@ -1,0 +1,104 @@
+package github.nighter.smartspawner.hooks.economy.shops.providers.excellentshop;
+
+import github.nighter.smartspawner.SmartSpawner;
+import github.nighter.smartspawner.hooks.economy.shops.providers.ShopProvider;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.plugin.Plugin;
+import su.nightexpress.excellentshop.ShopAPI;
+import su.nightexpress.excellentshop.api.product.ContentType;
+import su.nightexpress.excellentshop.api.product.Product;
+import su.nightexpress.excellentshop.virtualshop.VirtualShopModule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class ExcellentShopProvider implements ShopProvider {
+
+    private final SmartSpawner plugin;
+
+    // Cache: Material -> best sell price across all virtual shops
+    private final Map<Material, Double> priceCache = new HashMap<>();
+    private boolean cacheBuilt = false;
+
+    @Override
+    public String getPluginName() {
+        return "ExcellentShop";
+    }
+
+    @Override
+    public boolean isAvailable() {
+        try {
+            Plugin shopPlugin = Bukkit.getPluginManager().getPlugin("ExcellentShop");
+            if (shopPlugin == null || !shopPlugin.isEnabled()) return false;
+
+            Class.forName("su.nightexpress.excellentshop.ShopAPI");
+            Class.forName("su.nightexpress.excellentshop.virtualshop.VirtualShopModule");
+            return ShopAPI.isInitialized();
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            plugin.debug("ExcellentShop API not found: " + e.getMessage());
+        } catch (Exception e) {
+            plugin.getLogger().warning("Error initializing ExcellentShop integration: " + e.getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public double getSellPrice(Material material) {
+        if (material == null || material.isAir()) return 0.0;
+
+        try {
+            if (!cacheBuilt) buildCache();
+            return priceCache.getOrDefault(material, 0.0);
+        } catch (Exception e) {
+            plugin.debug("Error getting sell price for " + material + " from ExcellentShop: " + e.getMessage());
+            return 0.0;
+        }
+    }
+
+    /**
+     * Scans all virtual shop products and caches the best (highest) sell price
+     * per Material. Only considers sellable, item-type products.
+     * Called lazily on first price lookup so the shop data is fully loaded.
+     */
+    private void buildCache() {
+        priceCache.clear();
+        cacheBuilt = true;
+
+        try {
+            VirtualShopModule virtualShop = ShopAPI.getVirtualShop();
+            if (virtualShop == null) return;
+
+            virtualShop.getShops().forEach(shop ->
+                shop.getProductMap().values().forEach(product -> {
+                    if (!product.isSellable()) return;
+                    if (product.getContent().type() != ContentType.ITEM) return;
+
+                    Material material = product.getPreview().getType();
+                    if (material.isAir()) return;
+
+                    double sellPrice = product.getSellPrice();
+                    if (sellPrice <= 0) return;
+
+                    // Keep the highest sell price if the same material appears in multiple shops
+                    priceCache.merge(material, sellPrice, Math::max);
+                })
+            );
+
+            plugin.getLogger().info("[ExcellentShop] Price cache built: " + priceCache.size() + " materials indexed.");
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to build ExcellentShop price cache: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Invalidates the price cache. Call this when shop products may have changed
+     * (e.g. after a plugin reload).
+     */
+    public void invalidateCache() {
+        priceCache.clear();
+        cacheBuilt = false;
+    }
+}

--- a/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/excellentshop/ExcellentShopProvider.java
+++ b/core/src/main/java/github/nighter/smartspawner/hooks/economy/shops/providers/excellentshop/ExcellentShopProvider.java
@@ -5,23 +5,26 @@ import github.nighter.smartspawner.hooks.economy.shops.providers.ShopProvider;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.ServerLoadEvent;
 import org.bukkit.plugin.Plugin;
 import su.nightexpress.excellentshop.ShopAPI;
 import su.nightexpress.excellentshop.api.product.ContentType;
-import su.nightexpress.excellentshop.api.product.Product;
 import su.nightexpress.excellentshop.virtualshop.VirtualShopModule;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @RequiredArgsConstructor
-public class ExcellentShopProvider implements ShopProvider {
+public class ExcellentShopProvider implements ShopProvider, Listener {
 
     private final SmartSpawner plugin;
 
-    // Cache: Material -> best sell price across all virtual shops
-    private final Map<Material, Double> priceCache = new HashMap<>();
-    private boolean cacheBuilt = false;
+    // ConcurrentHashMap for Folia thread safety
+    private final Map<Material, Double> priceCache = new ConcurrentHashMap<>();
+    private final AtomicBoolean cacheBuilt = new AtomicBoolean(false);
 
     @Override
     public String getPluginName() {
@@ -32,18 +35,38 @@ public class ExcellentShopProvider implements ShopProvider {
     public boolean isAvailable() {
         try {
             Plugin shopPlugin = Bukkit.getPluginManager().getPlugin("ExcellentShop");
-            if (shopPlugin == null || !shopPlugin.isEnabled()) return false;
+            if (shopPlugin == null) {
+                plugin.getLogger().info("[ExcellentShop] Plugin not found on server.");
+                return false;
+            }
+            if (!shopPlugin.isEnabled()) {
+                plugin.getLogger().info("[ExcellentShop] Plugin found but not enabled.");
+                return false;
+            }
 
             Class.forName("su.nightexpress.excellentshop.ShopAPI");
             Class.forName("su.nightexpress.excellentshop.virtualshop.VirtualShopModule");
-            // Plugin is enabled — API will be initialized by the time we need it
+
+            // Register ServerLoadEvent listener to build cache after full startup
+            Bukkit.getPluginManager().registerEvents(this, plugin);
+
+            plugin.getLogger().info("[ExcellentShop] Integration ready. Price cache will build after server finishes loading.");
             return true;
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
-            plugin.debug("ExcellentShop API not found: " + e.getMessage());
+            plugin.getLogger().warning("[ExcellentShop] API classes not found: " + e.getMessage());
         } catch (Exception e) {
-            plugin.getLogger().warning("Error initializing ExcellentShop integration: " + e.getMessage());
+            plugin.getLogger().warning("[ExcellentShop] Error initializing: " + e.getMessage());
         }
         return false;
+    }
+
+    /**
+     * Build the cache after the server has fully started so ExcellentShop's
+     * async data load is complete and all prices are populated.
+     */
+    @EventHandler
+    public void onServerLoad(ServerLoadEvent event) {
+        buildCache();
     }
 
     @Override
@@ -51,7 +74,8 @@ public class ExcellentShopProvider implements ShopProvider {
         if (material == null || material.isAir()) return 0.0;
 
         try {
-            if (!cacheBuilt) buildCache();
+            // If cache hasn't been built yet (e.g. first call before ServerLoadEvent), build it now
+            if (!cacheBuilt.get()) buildCache();
             return priceCache.getOrDefault(material, 0.0);
         } catch (Exception e) {
             plugin.debug("Error getting sell price for " + material + " from ExcellentShop: " + e.getMessage());
@@ -62,15 +86,19 @@ public class ExcellentShopProvider implements ShopProvider {
     /**
      * Scans all virtual shop products and caches the best (highest) sell price
      * per Material. Only considers sellable, item-type products.
-     * Called lazily on first price lookup so the shop data is fully loaded.
      */
     private void buildCache() {
+        if (!cacheBuilt.compareAndSet(false, true)) return; // Only build once
+
         priceCache.clear();
-        cacheBuilt = true;
 
         try {
             VirtualShopModule virtualShop = ShopAPI.getVirtualShop();
-            if (virtualShop == null) return;
+            if (virtualShop == null) {
+                plugin.getLogger().warning("[ExcellentShop] VirtualShop module not available.");
+                cacheBuilt.set(false); // Allow retry
+                return;
+            }
 
             virtualShop.getShops().forEach(shop ->
                 shop.getProductMap().values().forEach(product -> {
@@ -81,25 +109,28 @@ public class ExcellentShopProvider implements ShopProvider {
                     if (material.isAir()) return;
 
                     double sellPrice = product.getSellPrice();
-                    if (sellPrice <= 0) return;
+                    if (sellPrice < 0) return; // -1 = disabled; 0 is valid
 
-                    // Keep the highest sell price if the same material appears in multiple shops
+                    // Keep the highest sell price if the same material is in multiple shops
                     priceCache.merge(material, sellPrice, Math::max);
                 })
             );
 
             plugin.getLogger().info("[ExcellentShop] Price cache built: " + priceCache.size() + " materials indexed.");
+            if (priceCache.isEmpty()) {
+                plugin.getLogger().warning("[ExcellentShop] Cache is empty — check that your virtual shops have sellable products.");
+            }
         } catch (Exception e) {
-            plugin.getLogger().warning("Failed to build ExcellentShop price cache: " + e.getMessage());
+            plugin.getLogger().warning("[ExcellentShop] Failed to build price cache: " + e.getMessage());
+            cacheBuilt.set(false); // Allow retry on next call
         }
     }
 
     /**
-     * Invalidates the price cache. Call this when shop products may have changed
-     * (e.g. after a plugin reload).
+     * Invalidates the price cache — call after shop prices change.
      */
     public void invalidateCache() {
         priceCache.clear();
-        cacheBuilt = false;
+        cacheBuilt.set(false);
     }
 }

--- a/core/src/main/resources/paper-plugin.yml
+++ b/core/src/main/resources/paper-plugin.yml
@@ -161,6 +161,10 @@ permissions:
     description: "Allow viewing sell prices of spawner items"
     default: true
 
+  smartspawner.command.priceanalysis:
+    description: "Allow viewing price analysis across all spawners"
+    default: op
+
   smartspawner.command.clear:
     description: "Allow clearing holograms and ghost spawners"
     default: op

--- a/core/src/main/resources/paper-plugin.yml
+++ b/core/src/main/resources/paper-plugin.yml
@@ -42,6 +42,10 @@ dependencies:
       load: BEFORE
       required: false
       join-classpath: true
+    ExcellentShop:
+      load: BEFORE
+      required: false
+      join-classpath: true
 
     # Economy Plugins
     ExcellentEconomy:

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -14,6 +14,7 @@ softdepend:
   - EconomyShopGUI-Premium
   - ShopGUIPlus
   - zShop
+  - ExcellentShop
 
   # Utility/Economy Plugins
   - ExcellentEconomy


### PR DESCRIPTION
## Summary

- ExcellentShop integration: adds `ExcellentShopProvider` so SmartSpawner can read sell prices directly from ExcellentShop v5 virtual shops
- `/ss priceanalysis` command: new admin command to audit price coverage across all spawner types with per-item source breakdown
- Build fixes: content filtering on nightexpress repo to prevent timeout cascades, `mavenLocal()` for locally built dependencies

## ExcellentShop Integration

Implements `ShopProvider` for ExcellentShop v5 (`su.nightexpress.excellentshop`):
- Scans all VirtualShop products on `ServerLoadEvent` (after async data load completes) and caches the best sell price per `Material`
- Only indexes items that are `isSellable()` and `ContentType.ITEM`
- Cache uses `ConcurrentHashMap` + `AtomicBoolean` for Folia thread safety
- `invalidateCache()` available for reload scenarios
- Added `ExcellentShop` to `paper-plugin.yml` dependencies with `load: BEFORE` to guarantee correct load order (Paper plugin vs Bukkit plugin ordering)

## /ss priceanalysis Command

Permission: `smartspawner.command.priceanalysis` (default: op)

```
/ss priceanalysis              -- full report across all spawner types
/ss priceanalysis <tab>        -- autocompletes only entity types with active spawners
/ss priceanalysis skeleton     -- individual lookup for one spawner type
```

Each item shows its resolved price source:
- `[Shop]` price from shop plugin (primary)
- `[Custom]` price from `item_prices.yml` (primary)
- `[Fallback]` secondary source used due to priority mode
- `[Not Configured]` no price found anywhere

Summary section with counts and a mode-aware hint for unconfigured items (e.g. in `SHOP_ONLY` mode it will not suggest `item_prices.yml`).

Fully respects all four `price_source_mode` values: `SHOP_PRIORITY`, `CUSTOM_PRIORITY`, `SHOP_ONLY`, `CUSTOM_ONLY`.

## Testing

Tested on Paper 1.21.11 and Canvas 1.21.11 (Folia fork) with ExcellentShop v5.1.1 and NightCore 2.15.3.