### PR TITLE
Add public removeSpawner API for addon integrations

### DIFF
--- a/api/src/main/java/github/nighter/smartspawner/api/SmartSpawnerAPI.java
+++ b/api/src/main/java/github/nighter/smartspawner/api/SmartSpawnerAPI.java
@@ -2,6 +2,8 @@ package github.nighter.smartspawner.api;
 
 import github.nighter.smartspawner.api.data.SpawnerDataDTO;
 import github.nighter.smartspawner.api.data.SpawnerDataModifier;
+import github.nighter.smartspawner.api.data.SpawnerRemovalOptions;
+import github.nighter.smartspawner.api.data.SpawnerRemovalResult;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
@@ -141,4 +143,46 @@ public interface SmartSpawnerAPI {
      * @return a spawner data modifier, or null if spawner doesn't exist
      */
     SpawnerDataModifier getSpawnerModifier(String spawnerId);
+
+    /**
+     * Removes a SmartSpawner cage at the given block location.
+     * <p>
+     * Must be called on the correct region thread for the target location (Paper/Folia).
+     *
+     * @param location the block location of the spawner cage
+     * @return the removal result
+     */
+    SpawnerRemovalResult removeSpawner(Location location);
+
+    /**
+     * Removes a SmartSpawner cage at the given block location with custom options.
+     * <p>
+     * Must be called on the correct region thread for the target location (Paper/Folia).
+     *
+     * @param location the block location of the spawner cage
+     * @param options removal options such as sell/claim behavior
+     * @return the removal result
+     */
+    SpawnerRemovalResult removeSpawner(Location location, SpawnerRemovalOptions options);
+
+    /**
+     * Removes a SmartSpawner cage by its unique identifier.
+     * <p>
+     * Must be called on the correct region thread for the spawner's location (Paper/Folia).
+     *
+     * @param spawnerId the unique spawner identifier
+     * @return the removal result
+     */
+    SpawnerRemovalResult removeSpawner(String spawnerId);
+
+    /**
+     * Removes a SmartSpawner cage by its unique identifier with custom options.
+     * <p>
+     * Must be called on the correct region thread for the spawner's location (Paper/Folia).
+     *
+     * @param spawnerId the unique spawner identifier
+     * @param options removal options such as sell/claim behavior
+     * @return the removal result
+     */
+    SpawnerRemovalResult removeSpawner(String spawnerId, SpawnerRemovalOptions options);
 }

--- a/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalOptions.java
+++ b/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalOptions.java
@@ -1,0 +1,77 @@
+package github.nighter.smartspawner.api.data;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Options for programmatic spawner removal through {@link github.nighter.smartspawner.api.SmartSpawnerAPI}.
+ */
+public final class SpawnerRemovalOptions {
+
+    private final SpawnerRemovalReason reason;
+    private final boolean sellAndClaimExp;
+    private final Player payoutPlayer;
+
+    private SpawnerRemovalOptions(Builder builder) {
+        this.reason = builder.reason;
+        this.sellAndClaimExp = builder.sellAndClaimExp;
+        this.payoutPlayer = builder.payoutPlayer;
+    }
+
+    public static @NotNull Builder builder() {
+        return new Builder();
+    }
+
+    public static @NotNull SpawnerRemovalOptions defaults() {
+        return builder().build();
+    }
+
+    public static @NotNull SpawnerRemovalOptions expired(@Nullable Player payoutPlayer) {
+        return builder()
+                .reason(SpawnerRemovalReason.EXPIRED)
+                .sellAndClaimExp(true)
+                .payoutPlayer(payoutPlayer)
+                .build();
+    }
+
+    public @NotNull SpawnerRemovalReason getReason() {
+        return reason;
+    }
+
+    public boolean isSellAndClaimExp() {
+        return sellAndClaimExp;
+    }
+
+    public @Nullable Player getPayoutPlayer() {
+        return payoutPlayer;
+    }
+
+    public static final class Builder {
+        private SpawnerRemovalReason reason = SpawnerRemovalReason.API;
+        private boolean sellAndClaimExp;
+        private Player payoutPlayer;
+
+        private Builder() {
+        }
+
+        public @NotNull Builder reason(@NotNull SpawnerRemovalReason reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        public @NotNull Builder sellAndClaimExp(boolean sellAndClaimExp) {
+            this.sellAndClaimExp = sellAndClaimExp;
+            return this;
+        }
+
+        public @NotNull Builder payoutPlayer(@Nullable Player payoutPlayer) {
+            this.payoutPlayer = payoutPlayer;
+            return this;
+        }
+
+        public @NotNull SpawnerRemovalOptions build() {
+            return new SpawnerRemovalOptions(this);
+        }
+    }
+}

--- a/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalOptions.java
+++ b/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalOptions.java
@@ -11,11 +11,13 @@ public final class SpawnerRemovalOptions {
 
     private final SpawnerRemovalReason reason;
     private final boolean sellAndClaimExp;
+    private final Player initiator;
     private final Player payoutPlayer;
 
     private SpawnerRemovalOptions(Builder builder) {
         this.reason = builder.reason;
         this.sellAndClaimExp = builder.sellAndClaimExp;
+        this.initiator = builder.initiator;
         this.payoutPlayer = builder.payoutPlayer;
     }
 
@@ -27,12 +29,15 @@ public final class SpawnerRemovalOptions {
         return builder().build();
     }
 
+    /**
+     * Preset for timed expiry addons. Auto-sell and claim XP only when {@code payoutPlayer} is online.
+     */
     public static @NotNull SpawnerRemovalOptions expired(@Nullable Player payoutPlayer) {
-        return builder()
-                .reason(SpawnerRemovalReason.EXPIRED)
-                .sellAndClaimExp(true)
-                .payoutPlayer(payoutPlayer)
-                .build();
+        Builder builder = builder().reason(SpawnerRemovalReason.EXPIRED);
+        if (payoutPlayer != null) {
+            builder.sellAndClaimExp(true).payoutPlayer(payoutPlayer);
+        }
+        return builder.build();
     }
 
     public @NotNull SpawnerRemovalReason getReason() {
@@ -43,6 +48,10 @@ public final class SpawnerRemovalOptions {
         return sellAndClaimExp;
     }
 
+    public @Nullable Player getInitiator() {
+        return initiator;
+    }
+
     public @Nullable Player getPayoutPlayer() {
         return payoutPlayer;
     }
@@ -50,6 +59,7 @@ public final class SpawnerRemovalOptions {
     public static final class Builder {
         private SpawnerRemovalReason reason = SpawnerRemovalReason.API;
         private boolean sellAndClaimExp;
+        private Player initiator;
         private Player payoutPlayer;
 
         private Builder() {
@@ -62,6 +72,11 @@ public final class SpawnerRemovalOptions {
 
         public @NotNull Builder sellAndClaimExp(boolean sellAndClaimExp) {
             this.sellAndClaimExp = sellAndClaimExp;
+            return this;
+        }
+
+        public @NotNull Builder initiator(@Nullable Player initiator) {
+            this.initiator = initiator;
             return this;
         }
 

--- a/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalReason.java
+++ b/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalReason.java
@@ -1,0 +1,27 @@
+package github.nighter.smartspawner.api.data;
+
+/**
+ * Describes why a SmartSpawner cage is being removed programmatically.
+ */
+public enum SpawnerRemovalReason {
+
+    /**
+     * Removed through the public API without a more specific reason.
+     */
+    API,
+
+    /**
+     * Removed because a timed lease or expiry policy elapsed.
+     */
+    EXPIRED,
+
+    /**
+     * Removed by an administrator or admin tooling.
+     */
+    ADMIN,
+
+    /**
+     * Removed for another plugin-defined reason.
+     */
+    OTHER
+}

--- a/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalResult.java
+++ b/api/src/main/java/github/nighter/smartspawner/api/data/SpawnerRemovalResult.java
@@ -1,0 +1,37 @@
+package github.nighter.smartspawner.api.data;
+
+/**
+ * Result of a programmatic spawner removal request.
+ */
+public enum SpawnerRemovalResult {
+
+    /**
+     * The spawner block and data were removed successfully.
+     */
+    SUCCESS,
+
+    /**
+     * No SmartSpawner cage exists at the requested location or ID.
+     */
+    NOT_FOUND,
+
+    /**
+     * A {@link github.nighter.smartspawner.api.events.SpawnerDestroyEvent} listener cancelled removal.
+     */
+    CANCELLED,
+
+    /**
+     * Another operation is already in progress at this spawner location.
+     */
+    LOCKED,
+
+    /**
+     * Stored items are being sold asynchronously; cleanup runs after sell completes.
+     */
+    SELL_PENDING,
+
+    /**
+     * Removal failed for an unexpected reason.
+     */
+    FAILED
+}

--- a/api/src/main/java/github/nighter/smartspawner/api/events/SpawnerDestroyEvent.java
+++ b/api/src/main/java/github/nighter/smartspawner/api/events/SpawnerDestroyEvent.java
@@ -1,0 +1,56 @@
+package github.nighter.smartspawner.api.events;
+
+import github.nighter.smartspawner.api.data.SpawnerRemovalReason;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Called before a SmartSpawner cage is removed programmatically through the public API.
+ * <p>
+ * This is distinct from {@link SpawnerRemoveEvent}, which fires when spawners are unstacked
+ * from the stacker GUI.
+ */
+@Getter
+public class SpawnerDestroyEvent extends SpawnerEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final SpawnerRemovalReason reason;
+    private final EntityType entityType;
+    private final Player initiator;
+    private final Player payoutPlayer;
+
+    @Setter
+    private boolean cancelled = false;
+
+    public SpawnerDestroyEvent(
+            @NotNull Location location,
+            int quantity,
+            @NotNull SpawnerRemovalReason reason,
+            @Nullable EntityType entityType,
+            @Nullable Player initiator,
+            @Nullable Player payoutPlayer
+    ) {
+        super(location, quantity);
+        this.reason = reason;
+        this.entityType = entityType;
+        this.initiator = initiator;
+        this.payoutPlayer = payoutPlayer;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static @NotNull HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,9 @@ allprojects {
         maven {
             name = "nightexpress-releases"
             url = uri("https://repo.nightexpressdev.com/releases")
+            content {
+                includeGroupByRegex("su\\.nightexpress.*")
+            }
         }
         maven {
             name = "iridiumdevelopment"
@@ -65,6 +68,14 @@ allprojects {
         maven {
             name = "minecodes-repository-releases"
             url = uri("https://maven.minecodes.pl/releases")
+            content {
+                includeGroup("pl.minecodes.plots")
+            }
+            metadataSources {
+                mavenPom()
+                artifact()
+            }
+            isAllowInsecureProtocol = false
         }
         maven {
             name = "william278Releases"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     compileOnly("com.bgsoftware:SuperiorSkyblockAPI:2026.1")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
     compileOnly("su.nightexpress.excellenteconomy:ExcellentEconomy:2.8.0")
-    compileOnly("su.nightexpress.nightcore:main:2.15.3")
+    compileOnly("su.nightexpress.nightcore:main:2.16.1")
     compileOnly("com.github.Gypopo:EconomyShopGUI-API:1.10.0")
     compileOnly("world.bentobox:bentobox:3.17.0")
     compileOnly("dev.aurelium:auraskills-api-bukkit:2.3.12")
@@ -43,6 +43,8 @@ dependencies {
     implementation("com.github.Xyness:SimpleClaimSystem:1.13.0.9")
     implementation("com.github.Zrips:Residence:6.0.0.1") {
         exclude(group = "org.bukkit")
+        exclude(group = "org.dynmap")
+        exclude(group = "nl.pim16aap2.BigDoors")
     }
 
     compileOnly("io.lumine:Mythic-Dist:5.12.1")

--- a/core/src/main/java/github/nighter/smartspawner/SmartSpawner.java
+++ b/core/src/main/java/github/nighter/smartspawner/SmartSpawner.java
@@ -43,6 +43,7 @@ import github.nighter.smartspawner.spawner.gui.sell.SpawnerSellConfirmListener;
 import github.nighter.smartspawner.spawner.interactions.click.SpawnerClickManager;
 import github.nighter.smartspawner.spawner.interactions.destroy.SpawnerBreakListener;
 import github.nighter.smartspawner.spawner.interactions.destroy.SpawnerExplosionListener;
+import github.nighter.smartspawner.spawner.interactions.destroy.SpawnerRemovalService;
 import github.nighter.smartspawner.spawner.interactions.place.SpawnerPlaceListener;
 import github.nighter.smartspawner.spawner.interactions.stack.SpawnerStackHandler;
 import github.nighter.smartspawner.spawner.interactions.type.SpawnEggHandler;
@@ -137,6 +138,7 @@ public class SmartSpawner extends JavaPlugin implements SmartSpawnerPlugin {
     private SpawnerGuiViewManager spawnerGuiViewManager;
     private SpawnerExplosionListener spawnerExplosionListener;
     private SpawnerBreakListener spawnerBreakListener;
+    private SpawnerRemovalService spawnerRemovalService;
     private SpawnerPlaceListener spawnerPlaceListener;
     private WorldEventHandler worldEventHandler;
     private ItemPriceManager itemPriceManager;
@@ -216,6 +218,7 @@ public class SmartSpawner extends JavaPlugin implements SmartSpawnerPlugin {
         // Initialize hopper handler if enabled in config
         setUpHopperHandler();
         initializeListeners();
+        this.spawnerRemovalService = new SpawnerRemovalService(this);
         this.apiImpl = new SmartSpawnerAPIImpl(this);
         this.updateChecker = new UpdateChecker(this);
     }

--- a/core/src/main/java/github/nighter/smartspawner/api/SmartSpawnerAPIImpl.java
+++ b/core/src/main/java/github/nighter/smartspawner/api/SmartSpawnerAPIImpl.java
@@ -202,6 +202,9 @@ public class SmartSpawnerAPIImpl implements SmartSpawnerAPI {
         if (location == null) {
             return SpawnerRemovalResult.NOT_FOUND;
         }
+        if (options == null) {
+            return SpawnerRemovalResult.FAILED;
+        }
 
         SpawnerData spawnerData = plugin.getSpawnerManager().getSpawnerByLocation(location);
         if (spawnerData == null) {
@@ -220,6 +223,9 @@ public class SmartSpawnerAPIImpl implements SmartSpawnerAPI {
     public SpawnerRemovalResult removeSpawner(String spawnerId, SpawnerRemovalOptions options) {
         if (spawnerId == null) {
             return SpawnerRemovalResult.NOT_FOUND;
+        }
+        if (options == null) {
+            return SpawnerRemovalResult.FAILED;
         }
 
         SpawnerData spawnerData = plugin.getSpawnerManager().getSpawnerById(spawnerId);

--- a/core/src/main/java/github/nighter/smartspawner/api/SmartSpawnerAPIImpl.java
+++ b/core/src/main/java/github/nighter/smartspawner/api/SmartSpawnerAPIImpl.java
@@ -3,6 +3,8 @@ package github.nighter.smartspawner.api;
 import github.nighter.smartspawner.SmartSpawner;
 import github.nighter.smartspawner.api.data.SpawnerDataDTO;
 import github.nighter.smartspawner.api.data.SpawnerDataModifier;
+import github.nighter.smartspawner.api.data.SpawnerRemovalOptions;
+import github.nighter.smartspawner.api.data.SpawnerRemovalResult;
 import github.nighter.smartspawner.api.impl.SpawnerDataModifierImpl;
 import github.nighter.smartspawner.spawner.item.SpawnerItemFactory;
 import github.nighter.smartspawner.spawner.properties.SpawnerData;
@@ -188,6 +190,44 @@ public class SmartSpawnerAPIImpl implements SmartSpawnerAPI {
 
         SpawnerData spawnerData = plugin.getSpawnerManager().getSpawnerById(spawnerId);
         return spawnerData != null ? new SpawnerDataModifierImpl(spawnerData) : null;
+    }
+
+    @Override
+    public SpawnerRemovalResult removeSpawner(Location location) {
+        return removeSpawner(location, SpawnerRemovalOptions.defaults());
+    }
+
+    @Override
+    public SpawnerRemovalResult removeSpawner(Location location, SpawnerRemovalOptions options) {
+        if (location == null) {
+            return SpawnerRemovalResult.NOT_FOUND;
+        }
+
+        SpawnerData spawnerData = plugin.getSpawnerManager().getSpawnerByLocation(location);
+        if (spawnerData == null) {
+            return SpawnerRemovalResult.NOT_FOUND;
+        }
+
+        return plugin.getSpawnerRemovalService().removeSpawner(spawnerData, options);
+    }
+
+    @Override
+    public SpawnerRemovalResult removeSpawner(String spawnerId) {
+        return removeSpawner(spawnerId, SpawnerRemovalOptions.defaults());
+    }
+
+    @Override
+    public SpawnerRemovalResult removeSpawner(String spawnerId, SpawnerRemovalOptions options) {
+        if (spawnerId == null) {
+            return SpawnerRemovalResult.NOT_FOUND;
+        }
+
+        SpawnerData spawnerData = plugin.getSpawnerManager().getSpawnerById(spawnerId);
+        if (spawnerData == null) {
+            return SpawnerRemovalResult.NOT_FOUND;
+        }
+
+        return plugin.getSpawnerRemovalService().removeSpawner(spawnerData, options);
     }
 
     /**

--- a/core/src/main/java/github/nighter/smartspawner/commands/list/gui/management/SpawnerManagementHandler.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/list/gui/management/SpawnerManagementHandler.java
@@ -118,18 +118,8 @@ public class SpawnerManagementHandler implements Listener {
     }
 
     private void handleRemoveSpawner(Player player, SpawnerData spawner, String worldName, int listPage) {
-        // Remove the spawner block and data
         Location loc = spawner.getSpawnerLocation();
-        plugin.getSpawnerGuiViewManager().closeAllViewersInventory(spawner);
-        String spawnerId = spawner.getSpawnerId();
-        spawner.getSpawnerStop().set(true);
-        if (loc.getBlock().getType() == Material.SPAWNER) {
-            loc.getBlock().setType(Material.AIR);
-        }
-
-        // Remove from manager and save
-        spawnerManager.removeSpawner(spawnerId);
-        spawnerStorage.markSpawnerDeleted(spawnerId);
+        plugin.getSpawnerRemovalService().performCleanup(loc.getBlock(), spawner);
         Map<String, String> placeholders = new HashMap<>();
         placeholders.put("id", spawner.getSpawnerId());
         messageService.sendMessage(player, "list.spawner_removed", placeholders);

--- a/core/src/main/java/github/nighter/smartspawner/commands/list/gui/management/SpawnerManagementHandler.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/list/gui/management/SpawnerManagementHandler.java
@@ -1,6 +1,9 @@
 package github.nighter.smartspawner.commands.list.gui.management;
 
 import github.nighter.smartspawner.SmartSpawner;
+import github.nighter.smartspawner.api.data.SpawnerRemovalOptions;
+import github.nighter.smartspawner.api.data.SpawnerRemovalReason;
+import github.nighter.smartspawner.api.data.SpawnerRemovalResult;
 import github.nighter.smartspawner.commands.list.gui.adminstacker.AdminStackerUI;
 import github.nighter.smartspawner.commands.list.ListSubCommand;
 import github.nighter.smartspawner.commands.list.gui.list.enums.FilterOption;
@@ -118,8 +121,20 @@ public class SpawnerManagementHandler implements Listener {
     }
 
     private void handleRemoveSpawner(Player player, SpawnerData spawner, String worldName, int listPage) {
-        Location loc = spawner.getSpawnerLocation();
-        plugin.getSpawnerRemovalService().performCleanup(loc.getBlock(), spawner);
+        SpawnerRemovalOptions options = SpawnerRemovalOptions.builder()
+                .reason(SpawnerRemovalReason.ADMIN)
+                .initiator(player)
+                .build();
+        SpawnerRemovalResult result = plugin.getSpawnerRemovalService().removeSpawner(spawner, options);
+        if (result == SpawnerRemovalResult.LOCKED) {
+            messageService.sendMessage(player, "action_in_progress");
+            return;
+        }
+        if (result != SpawnerRemovalResult.SUCCESS && result != SpawnerRemovalResult.SELL_PENDING) {
+            messageService.sendMessage(player, "action_failed");
+            return;
+        }
+
         Map<String, String> placeholders = new HashMap<>();
         placeholders.put("id", spawner.getSpawnerId());
         messageService.sendMessage(player, "list.spawner_removed", placeholders);

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
@@ -109,9 +109,6 @@ public class SpawnerBreakListener implements Listener {
         }
 
         event.setCancelled(true);
-        if (breakHandled) {
-            cleanupAssociatedHopper(block);
-        }
     }
 
     private boolean handleSmartSpawnerBreak(Block block, SpawnerData spawner, Player player) {
@@ -226,6 +223,7 @@ public class SpawnerBreakListener implements Listener {
                 }
 
                 reduceDurability(tool, player, breakConfig.getDurabilityLoss());
+                cleanupAssociatedHopper(block);
                 return true;
             }
 

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerBreakListener.java
@@ -426,17 +426,7 @@ public class SpawnerBreakListener implements Listener {
     }
 
     private void cleanupSpawner(Block block, SpawnerData spawner) {
-        spawner.getSpawnerStop().set(true);
-        block.setType(Material.AIR);
-
-        String spawnerId = spawner.getSpawnerId();
-        plugin.getRangeChecker().deactivateSpawner(spawner);
-        spawnerManager.removeSpawner(spawnerId);
-        spawnerManager.markSpawnerDeleted(spawnerId);
-
-        // Remove location lock to prevent memory leak
-        Location location = block.getLocation();
-        locationLockManager.removeLock(location);
+        plugin.getSpawnerRemovalService().performCleanup(block, spawner);
     }
 
     /**
@@ -604,6 +594,7 @@ public class SpawnerBreakListener implements Listener {
         SpawnerMenuAction getSpawnerMenuAction();
         github.nighter.smartspawner.spawner.sell.SpawnerSellManager getSpawnerSellManager();
         github.nighter.smartspawner.spawner.lootgen.SpawnerRangeChecker getRangeChecker();
+        SpawnerRemovalService getSpawnerRemovalService();
     }
 
     private static final class SmartSpawnerBreakPluginContext implements BreakPluginContext {
@@ -624,5 +615,6 @@ public class SpawnerBreakListener implements Listener {
         @Override public SpawnerMenuAction getSpawnerMenuAction() { return plugin.getSpawnerMenuAction(); }
         @Override public github.nighter.smartspawner.spawner.sell.SpawnerSellManager getSpawnerSellManager() { return plugin.getSpawnerSellManager(); }
         @Override public github.nighter.smartspawner.spawner.lootgen.SpawnerRangeChecker getRangeChecker() { return plugin.getRangeChecker(); }
+        @Override public SpawnerRemovalService getSpawnerRemovalService() { return plugin.getSpawnerRemovalService(); }
     }
 }

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerRemovalService.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerRemovalService.java
@@ -1,0 +1,160 @@
+package github.nighter.smartspawner.spawner.interactions.destroy;
+
+import github.nighter.smartspawner.SmartSpawner;
+import github.nighter.smartspawner.api.data.SpawnerRemovalOptions;
+import github.nighter.smartspawner.api.data.SpawnerRemovalResult;
+import github.nighter.smartspawner.api.events.SpawnerDestroyEvent;
+import github.nighter.smartspawner.extras.HopperService;
+import github.nighter.smartspawner.spawner.data.SpawnerManager;
+import github.nighter.smartspawner.spawner.gui.main.SpawnerMenuAction;
+import github.nighter.smartspawner.spawner.gui.synchronization.SpawnerGuiViewManager;
+import github.nighter.smartspawner.spawner.lootgen.SpawnerRangeChecker;
+import github.nighter.smartspawner.spawner.properties.SpawnerData;
+import github.nighter.smartspawner.spawner.sell.SpawnerSellManager;
+import github.nighter.smartspawner.spawner.utils.SpawnerLocationLockManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+/**
+ * Central service for programmatic SmartSpawner cage removal.
+ */
+public class SpawnerRemovalService {
+
+    private final SmartSpawner plugin;
+    private final SpawnerManager spawnerManager;
+    private final SpawnerLocationLockManager locationLockManager;
+    private final SpawnerGuiViewManager guiViewManager;
+    private final SpawnerRangeChecker rangeChecker;
+    private final SpawnerMenuAction menuAction;
+    private final SpawnerSellManager sellManager;
+
+    public SpawnerRemovalService(SmartSpawner plugin) {
+        this.plugin = plugin;
+        this.spawnerManager = plugin.getSpawnerManager();
+        this.locationLockManager = plugin.getSpawnerLocationLockManager();
+        this.guiViewManager = plugin.getSpawnerGuiViewManager();
+        this.rangeChecker = plugin.getRangeChecker();
+        this.menuAction = plugin.getSpawnerMenuAction();
+        this.sellManager = plugin.getSpawnerSellManager();
+    }
+
+    public SpawnerRemovalResult removeSpawner(SpawnerData spawner, SpawnerRemovalOptions options) {
+        if (spawner == null || options == null) {
+            return SpawnerRemovalResult.NOT_FOUND;
+        }
+
+        Location location = spawner.getSpawnerLocation();
+        if (location.getWorld() == null) {
+            return SpawnerRemovalResult.FAILED;
+        }
+
+        SpawnerData currentSpawner = spawnerManager.getSpawnerByLocation(location);
+        if (currentSpawner == null || !currentSpawner.getSpawnerId().equals(spawner.getSpawnerId())) {
+            return SpawnerRemovalResult.NOT_FOUND;
+        }
+
+        if (!locationLockManager.tryLock(location)) {
+            return SpawnerRemovalResult.LOCKED;
+        }
+
+        try {
+            currentSpawner = spawnerManager.getSpawnerByLocation(location);
+            if (currentSpawner == null) {
+                return SpawnerRemovalResult.NOT_FOUND;
+            }
+
+            if (currentSpawner.isSelling()) {
+                return SpawnerRemovalResult.LOCKED;
+            }
+
+            Player payoutPlayer = options.getPayoutPlayer();
+            if (shouldFireDestroyEvent()) {
+                SpawnerDestroyEvent event = new SpawnerDestroyEvent(
+                        location.clone(),
+                        currentSpawner.getStackSize(),
+                        options.getReason(),
+                        currentSpawner.getEntityType(),
+                        payoutPlayer,
+                        payoutPlayer
+                );
+                Bukkit.getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    return SpawnerRemovalResult.CANCELLED;
+                }
+            }
+
+            guiViewManager.closeAllViewersInventory(currentSpawner);
+            Block block = location.getBlock();
+            Runnable cleanup = () -> performCleanup(block, currentSpawner);
+
+            if (options.isSellAndClaimExp() && payoutPlayer != null) {
+                boolean sellDeferred = maybeSellAndClaimExp(payoutPlayer, currentSpawner, cleanup);
+                if (sellDeferred) {
+                    return SpawnerRemovalResult.SELL_PENDING;
+                }
+            }
+
+            cleanup.run();
+            return SpawnerRemovalResult.SUCCESS;
+        } catch (Exception exception) {
+            plugin.getLogger().warning("Failed to remove spawner " + spawner.getSpawnerId() + ": " + exception.getMessage());
+            return SpawnerRemovalResult.FAILED;
+        } finally {
+            locationLockManager.unlock(location);
+        }
+    }
+
+    public void performCleanup(Block block, SpawnerData spawner) {
+        spawner.getSpawnerStop().set(true);
+
+        if (block.getType() == Material.SPAWNER) {
+            block.setType(Material.AIR);
+        }
+
+        String spawnerId = spawner.getSpawnerId();
+        rangeChecker.deactivateSpawner(spawner);
+        spawnerManager.removeSpawner(spawnerId);
+        spawnerManager.markSpawnerDeleted(spawnerId);
+
+        Location location = block.getLocation();
+        locationLockManager.removeLock(location);
+        cleanupAssociatedHopper(block);
+    }
+
+    private boolean maybeSellAndClaimExp(Player player, SpawnerData spawner, Runnable onComplete) {
+        if (menuAction != null && spawner.getSpawnerExp() > 0) {
+            menuAction.collectExpForPlayer(player, spawner);
+        }
+
+        if (!plugin.hasSellIntegration() || !player.hasPermission("smartspawner.sellall")) {
+            return false;
+        }
+
+        if (spawner.getVirtualInventory().getUsedSlots() <= 0) {
+            return false;
+        }
+
+        sellManager.sellAllItems(player, spawner, () -> {
+            if (spawner.getVirtualInventory().getUsedSlots() > 0) {
+                return;
+            }
+            onComplete.run();
+        });
+        return true;
+    }
+
+    private void cleanupAssociatedHopper(Block block) {
+        HopperService hopperService = plugin.getHopperService();
+        if (hopperService == null) {
+            return;
+        }
+        hopperService.getTracker().removeBelowSpawner(block);
+    }
+
+    private boolean shouldFireDestroyEvent() {
+        return SpawnerDestroyEvent.getHandlerList().getRegisteredListeners().length > 0;
+    }
+}

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerRemovalService.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerRemovalService.java
@@ -42,8 +42,14 @@ public class SpawnerRemovalService {
     }
 
     public SpawnerRemovalResult removeSpawner(SpawnerData spawner, SpawnerRemovalOptions options) {
-        if (spawner == null || options == null) {
+        if (spawner == null) {
             return SpawnerRemovalResult.NOT_FOUND;
+        }
+        if (options == null) {
+            return SpawnerRemovalResult.FAILED;
+        }
+        if (options.isSellAndClaimExp() && options.getPayoutPlayer() == null) {
+            return SpawnerRemovalResult.FAILED;
         }
 
         Location location = spawner.getSpawnerLocation();
@@ -60,6 +66,14 @@ public class SpawnerRemovalService {
             return SpawnerRemovalResult.LOCKED;
         }
 
+        boolean lockReleased = false;
+        Runnable releaseLock = () -> {
+            if (!lockReleased) {
+                locationLockManager.unlock(location);
+                lockReleased = true;
+            }
+        };
+
         try {
             currentSpawner = spawnerManager.getSpawnerByLocation(location);
             if (currentSpawner == null) {
@@ -70,6 +84,7 @@ public class SpawnerRemovalService {
                 return SpawnerRemovalResult.LOCKED;
             }
 
+            Player initiator = options.getInitiator();
             Player payoutPlayer = options.getPayoutPlayer();
             if (shouldFireDestroyEvent()) {
                 SpawnerDestroyEvent event = new SpawnerDestroyEvent(
@@ -77,7 +92,7 @@ public class SpawnerRemovalService {
                         currentSpawner.getStackSize(),
                         options.getReason(),
                         currentSpawner.getEntityType(),
-                        payoutPlayer,
+                        initiator,
                         payoutPlayer
                 );
                 Bukkit.getPluginManager().callEvent(event);
@@ -88,26 +103,47 @@ public class SpawnerRemovalService {
 
             guiViewManager.closeAllViewersInventory(currentSpawner);
             Block block = location.getBlock();
-            Runnable cleanup = () -> performCleanup(block, currentSpawner);
+            final SpawnerData spawnerForCleanup = currentSpawner;
+            Runnable cleanup = () -> performCleanup(block, spawnerForCleanup);
+            Runnable cleanupAndReleaseLock = () -> {
+                try {
+                    cleanup.run();
+                } finally {
+                    releaseLock.run();
+                }
+            };
 
             if (options.isSellAndClaimExp() && payoutPlayer != null) {
-                boolean sellDeferred = maybeSellAndClaimExp(payoutPlayer, currentSpawner, cleanup);
+                boolean sellDeferred = maybeSellAndClaimExp(
+                        payoutPlayer,
+                        currentSpawner,
+                        cleanupAndReleaseLock,
+                        releaseLock
+                );
                 if (sellDeferred) {
+                    lockReleased = true;
                     return SpawnerRemovalResult.SELL_PENDING;
                 }
             }
 
-            cleanup.run();
+            cleanupAndReleaseLock.run();
+            lockReleased = true;
             return SpawnerRemovalResult.SUCCESS;
         } catch (Exception exception) {
             plugin.getLogger().warning("Failed to remove spawner " + spawner.getSpawnerId() + ": " + exception.getMessage());
             return SpawnerRemovalResult.FAILED;
         } finally {
-            locationLockManager.unlock(location);
+            if (!lockReleased) {
+                releaseLock.run();
+            }
         }
     }
 
-    public void performCleanup(Block block, SpawnerData spawner) {
+    /**
+     * Internal cleanup used by player break flow. Public API callers should use {@link #removeSpawner}.
+     */
+    void performCleanup(Block block, SpawnerData spawner) {
+        guiViewManager.closeAllViewersInventory(spawner);
         spawner.getSpawnerStop().set(true);
 
         if (block.getType() == Material.SPAWNER) {
@@ -124,7 +160,12 @@ public class SpawnerRemovalService {
         cleanupAssociatedHopper(block);
     }
 
-    private boolean maybeSellAndClaimExp(Player player, SpawnerData spawner, Runnable onComplete) {
+    private boolean maybeSellAndClaimExp(
+            Player player,
+            SpawnerData spawner,
+            Runnable onComplete,
+            Runnable onAbort
+    ) {
         if (menuAction != null && spawner.getSpawnerExp() > 0) {
             menuAction.collectExpForPlayer(player, spawner);
         }
@@ -139,6 +180,7 @@ public class SpawnerRemovalService {
 
         sellManager.sellAllItems(player, spawner, () -> {
             if (spawner.getVirtualInventory().getUsedSlots() > 0) {
+                onAbort.run();
                 return;
             }
             onComplete.run();

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerRemovalService.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/destroy/SpawnerRemovalService.java
@@ -18,6 +18,8 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * Central service for programmatic SmartSpawner cage removal.
  */
@@ -66,11 +68,10 @@ public class SpawnerRemovalService {
             return SpawnerRemovalResult.LOCKED;
         }
 
-        boolean lockReleased = false;
+        AtomicBoolean lockReleased = new AtomicBoolean(false);
         Runnable releaseLock = () -> {
-            if (!lockReleased) {
+            if (lockReleased.compareAndSet(false, true)) {
                 locationLockManager.unlock(location);
-                lockReleased = true;
             }
         };
 
@@ -121,19 +122,19 @@ public class SpawnerRemovalService {
                         releaseLock
                 );
                 if (sellDeferred) {
-                    lockReleased = true;
+                    lockReleased.set(true);
                     return SpawnerRemovalResult.SELL_PENDING;
                 }
             }
 
             cleanupAndReleaseLock.run();
-            lockReleased = true;
+            lockReleased.set(true);
             return SpawnerRemovalResult.SUCCESS;
         } catch (Exception exception) {
             plugin.getLogger().warning("Failed to remove spawner " + spawner.getSpawnerId() + ": " + exception.getMessage());
             return SpawnerRemovalResult.FAILED;
         } finally {
-            if (!lockReleased) {
+            if (!lockReleased.get()) {
                 releaseLock.run();
             }
         }

--- a/docs/src/content/docs/developer-api/api-data-access.md
+++ b/docs/src/content/docs/developer-api/api-data-access.md
@@ -188,7 +188,8 @@ if (result == SpawnerRemovalResult.SELL_PENDING) {
 | Option | Description |
 |--------|-------------|
 | `reason` | Why the spawner is being removed (`API`, `EXPIRED`, `ADMIN`, `OTHER`) |
-| `sellAndClaimExp` | Sell stored items and claim XP before removal |
+| `sellAndClaimExp` | Sell stored items and claim XP before removal (requires `payoutPlayer`) |
+| `initiator` | Player who triggered the removal (admin, command, etc.) |
 | `payoutPlayer` | Player who receives sell payout / claimed XP |
 
 ### Reading and Modifying Base Values

--- a/docs/src/content/docs/developer-api/api-data-access.md
+++ b/docs/src/content/docs/developer-api/api-data-access.md
@@ -10,6 +10,10 @@ description: Methods for accessing and modifying spawner data and properties.
 | `getSpawnerById(String)` | Gets spawner data by unique ID | `SpawnerDataDTO` |
 | `getAllSpawners()` | Gets all registered spawners | `List<SpawnerDataDTO>` |
 | `getSpawnerModifier(String)` | Gets modifier to change spawner properties | `SpawnerDataModifier` |
+| `removeSpawner(Location)` | Removes a spawner cage at a block location | `SpawnerRemovalResult` |
+| `removeSpawner(Location, SpawnerRemovalOptions)` | Removes a spawner cage with custom options | `SpawnerRemovalResult` |
+| `removeSpawner(String)` | Removes a spawner cage by ID | `SpawnerRemovalResult` |
+| `removeSpawner(String, SpawnerRemovalOptions)` | Removes a spawner cage by ID with custom options | `SpawnerRemovalResult` |
 
 ### SpawnerDataDTO
 
@@ -152,6 +156,40 @@ if (modifier != null) {
     player.sendMessage("Note: Stack size cannot be modified (read-only)");
 }
 ```
+
+### `removeSpawner()`
+
+Programmatically removes a SmartSpawner cage and its persisted data. Must be called on the correct region thread for the spawner location (Paper/Folia).
+
+```java
+import github.nighter.smartspawner.api.data.SpawnerRemovalOptions;
+import github.nighter.smartspawner.api.data.SpawnerRemovalResult;
+
+SpawnerRemovalResult result = api.removeSpawner(location);
+
+if (result == SpawnerRemovalResult.SUCCESS) {
+    getLogger().info("Spawner removed successfully.");
+}
+```
+
+For expiry-style addons that should auto-sell stored items and claim XP for an online player:
+
+```java
+SpawnerRemovalOptions options = SpawnerRemovalOptions.expired(onlineOwner);
+SpawnerRemovalResult result = api.removeSpawner(spawnerId, options);
+
+if (result == SpawnerRemovalResult.SELL_PENDING) {
+    // Stored items are being sold asynchronously; cleanup runs after sell completes.
+}
+```
+
+`SpawnerRemovalOptions` supports:
+
+| Option | Description |
+|--------|-------------|
+| `reason` | Why the spawner is being removed (`API`, `EXPIRED`, `ADMIN`, `OTHER`) |
+| `sellAndClaimExp` | Sell stored items and claim XP before removal |
+| `payoutPlayer` | Player who receives sell payout / claimed XP |
 
 ### Reading and Modifying Base Values
 

--- a/docs/src/content/docs/developer-api/api-events.md
+++ b/docs/src/content/docs/developer-api/api-events.md
@@ -17,6 +17,7 @@ SmartSpawner provides various events to hook into spawner-related actions:
 | `SpawnerEggChangeEvent`   | Spawner type changed with egg                    |      ✅     |
 | `SpawnerExplodeEvent`     | Spawners destroyed by explosion                  |      ❌     |
 | `SpawnerRemoveEvent`      | Unstack spawners from the stacker GUI            |      ✅     |
+| `SpawnerDestroyEvent`     | Spawner removed programmatically through the API   |      ✅     |
 | `SpawnerOpenGUIEvent`     | GUI opened by player                             |      ✅     |
 | `SpawnerDropAllEvent`     | Dropping all item from a page of spawner storage |      ✅      |
 | `SpawnerTakeAllEvent`     | Taking all item from a page of spawner storage   |      ✅      |


### PR DESCRIPTION
## Summary

- Adds `SmartSpawnerAPI.removeSpawner(...)` overloads for location and spawner ID removal
- Introduces `SpawnerRemovalOptions`, `SpawnerRemovalReason`, and `SpawnerRemovalResult` for expiry/admin addon use cases
- Fires cancellable `SpawnerDestroyEvent` before programmatic removal (distinct from GUI `SpawnerRemoveEvent`)
- Centralizes block/data cleanup in `SpawnerRemovalService`, reused by player break and admin list removal flows
- Supports optional sell-and-claim-XP payout via `SpawnerRemovalOptions.expired(Player)` for timed spawner expiry addons
- Updates developer API docs for removal methods and the new destroy event

## Motivation

Third-party addons (e.g. spawner lease/expiry systems) need a supported way to delete SmartSpawner cages without leaving ghost data in `spawners_data.yml`. The current public API exposes read/modify helpers but no removal method, forcing fragile reflection or manual `setType(AIR)` workarounds.

## API usage example

```java
SmartSpawnerAPI api = SmartSpawnerProvider.getAPI();

SpawnerRemovalOptions options = SpawnerRemovalOptions.expired(onlineOwner);
SpawnerRemovalResult result = api.removeSpawner(location, options);

switch (result) {
    case SUCCESS -> { /* removed immediately */ }
    case SELL_PENDING -> { /* items sold async, cleanup follows */ }
    case CANCELLED -> { /* SpawnerDestroyEvent cancelled removal */ }
    default -> { /* NOT_FOUND, LOCKED, FAILED */ }
}
```

## Test plan

- [ ] Build `:api` module (`./gradlew :api:build`)
- [ ] Place a SmartSpawner cage, call `api.removeSpawner(location)` on region thread, verify block removed and entry deleted from storage
- [ ] Register `SpawnerDestroyEvent` listener, cancel event, verify cage remains
- [ ] Fill spawner storage + XP, call `SpawnerRemovalOptions.expired(player)`, verify sell/claim then removal
- [ ] Break spawner with pickaxe and remove via admin list GUI to confirm existing flows still work