### PR TITLE
feat: Add global default drop chance for natural spawners

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/config/Config.java
+++ b/core/src/main/java/github/nighter/smartspawner/config/Config.java
@@ -20,6 +20,9 @@ public class Config {
     @Getter(AccessLevel.NONE)
     private static volatile Config instance;
 
+    // Special key inside natural_spawner.drop_chance that applies to every spawner type
+    private static final String DEFAULT_DROP_CHANCE_KEY = "default";
+
     // Performance settings
     private final boolean approximateLoot;
     private final int approximationThreshold;
@@ -47,6 +50,8 @@ public class Config {
     private final Set<Material> requiredTools;
     @Getter(AccessLevel.NONE)
     private final Map<EntityType, Double> naturalSpawnerDropChances;
+    @Getter(AccessLevel.NONE)
+    private final double naturalSpawnerDefaultDropChance;
 
     private Config(FileConfiguration config, Logger logger) {
         // Performance settings
@@ -73,6 +78,7 @@ public class Config {
 
         // Parsed lookup data
         this.requiredTools = loadRequiredTools(config, logger);
+        this.naturalSpawnerDefaultDropChance = loadNaturalSpawnerDefaultDropChance(config, logger);
         this.naturalSpawnerDropChances = loadNaturalSpawnerDropChances(config, logger);
     }
 
@@ -93,7 +99,7 @@ public class Config {
     }
 
     public double getNaturalSpawnerDropChance(EntityType entityType) {
-        return naturalSpawnerDropChances.getOrDefault(entityType, 100.0);
+        return naturalSpawnerDropChances.getOrDefault(entityType, naturalSpawnerDefaultDropChance);
     }
 
     private static Set<Material> loadRequiredTools(FileConfiguration config, Logger logger) {
@@ -111,6 +117,16 @@ public class Config {
                 .collect(Collectors.toUnmodifiableSet());
     }
 
+    private static double loadNaturalSpawnerDefaultDropChance(FileConfiguration config, Logger logger) {
+        double defaultDropChance = config.getDouble("natural_spawner.drop_chance." + DEFAULT_DROP_CHANCE_KEY, 100.0);
+        if (defaultDropChance < 0.0 || defaultDropChance > 100.0) {
+            logger.warning("Invalid drop chance for natural_spawner.drop_chance." + DEFAULT_DROP_CHANCE_KEY +
+                    ". Value must be between 0.0 and 100.0; using 100.0");
+            defaultDropChance = 100.0;
+        }
+        return defaultDropChance;
+    }
+
     private static Map<EntityType, Double> loadNaturalSpawnerDropChances(FileConfiguration config, Logger logger) {
         ConfigurationSection section = config.getConfigurationSection("natural_spawner.drop_chance");
         if (section == null) {
@@ -119,6 +135,11 @@ public class Config {
 
         Map<EntityType, Double> loadedDropChances = new EnumMap<>(EntityType.class);
         for (String entityName : section.getKeys(false)) {
+            // The "default" key sets the drop chance for all spawner types and is handled separately.
+            if (entityName.equalsIgnoreCase(DEFAULT_DROP_CHANCE_KEY)) {
+                continue;
+            }
+
             EntityType entityType;
             try {
                 entityType = EntityType.valueOf(entityName.toUpperCase());

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -87,11 +87,15 @@ natural_spawner:
   # If false, natural spawners will drop vanilla spawner items
   convert_to_smart_spawner: false
 
-  # Optional spawner item drop chance by entity type when natural spawners are broken.
-  # If this section or an entity is omitted, the drop chance defaults to 100.0.
+  # Optional spawner item drop chance when natural spawners are broken.
   # Values must be percentages from 0.0 to 100.0.
+  #
+  # Use the "default" key to set the drop chance for ALL spawner types at once.
+  # Add specific entity types only when you want to override that default.
+  # If "default" is omitted, any unspecified entity falls back to 100.0.
   # drop_chance:
-  #   ZOMBIE: 75.0
+  #   default: 50.0   # applies to every spawner type
+  #   ZOMBIE: 75.0    # override for a specific type
   #   SKELETON: 50.0
   #   BLAZE: 25.0
 

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -132,6 +132,7 @@ natural_spawner:
   breakable: false
   convert_to_smart_spawner: false
   # drop_chance:
+  #   default: 50.0
   #   ZOMBIE: 75.0
   #   SKELETON: 50.0
   #   BLAZE: 25.0
@@ -141,7 +142,7 @@ natural_spawner:
 
 - `breakable`: Allows naturally generated vanilla spawners to be broken.
 - `convert_to_smart_spawner`: If `true`, broken natural spawners become Smart Spawners. If `false`, they drop vanilla spawner items.
-- `drop_chance`: Optional entity-specific chance for broken natural spawners to drop a spawner item. Omit the section, or omit an entity, to use the default `100.0`.
+- `drop_chance`: Optional chance for broken natural spawners to drop a spawner item. Use the `default` key to set one chance for **all** spawner types at once, and add specific entity types only to override that default. If `default` is omitted, any unspecified entity falls back to `100.0`.
 - `spawn_mobs`: Allows natural spawners to spawn mobs.
 - `protect_from_explosions`: Protects natural spawner blocks from explosions.
 


### PR DESCRIPTION
## Problem

Currently the drop chance for vanilla/natural spawners (obtained by mining with a Silk Touch pickaxe) can only be configured **per entity type** under `natural_spawner.drop_chance`. There is no way to set a single drop chance that applies to all spawner types at once — you'd have to list every entity individually, which is very inconvenient.

## Solution

Added a special `default` key under `natural_spawner.drop_chance` that sets the drop chance for **all** spawner types at once. Specific entity types can still be listed to override that default.

```yaml
natural_spawner:
  drop_chance:
    default: 50.0    # applies to every spawner type
    ZOMBIE: 75.0     # override for a specific type
    SKELETON: 50.0
    BLAZE: 25.0
```

Priority: specific entity type → `default` → `100.0` (when neither is set).

## Notes

- **Fully backwards compatible**: configs without a `default` key behave exactly as before (unspecified entities default to `100.0`).
- The `default` value is validated to the `0.0`–`100.0` range, same as per-entity values.
- Config migration already preserves any user values under `natural_spawner.drop_chance.*` (via `isOptionalDropChancePath`), so the `default` key carries over on version updates automatically.
- Documentation (`config.yml` comments and `configuration.md`) updated accordingly.

## Changes

- `Config.java` — new `naturalSpawnerDefaultDropChance` field, reads/validates the `default` key, skips it during per-entity parsing, and uses it as the fallback in `getNaturalSpawnerDropChance`.
- `config.yml` — updated example and comments.
- `configuration.md` — updated docs.

Built successfully with `./gradlew build`.