### PR TITLE
fix(logging): rename isEventEnabled to shouldLogEvent

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/logging/LoggingConfig.java
+++ b/core/src/main/java/github/nighter/smartspawner/logging/LoggingConfig.java
@@ -97,7 +97,7 @@ public class LoggingConfig {
         return new HashSet<>(enabledEvents);
     }
 
-    public boolean isEventEnabled(SpawnerEventType eventType) {
-        return !enabled || !enabledEvents.contains(eventType);
+    public boolean shouldLogEvent(SpawnerEventType eventType) {
+        return enabled && enabledEvents.contains(eventType);
     }
 }

--- a/core/src/main/java/github/nighter/smartspawner/logging/SpawnerActionLogger.java
+++ b/core/src/main/java/github/nighter/smartspawner/logging/SpawnerActionLogger.java
@@ -58,7 +58,7 @@ public class SpawnerActionLogger {
      * Logs a spawner action asynchronously.
      */
     public void log(SpawnerLogEntry entry) {
-        if (!config.isEnabled() || config.isEventEnabled(entry.getEventType())) {
+        if (!config.isEnabled() || !config.shouldLogEvent(entry.getEventType())) {
             return;
         }
         
@@ -79,7 +79,7 @@ public class SpawnerActionLogger {
      * Logs a spawner action using a builder pattern.
      */
     public void log(SpawnerEventType eventType, LogEntryConsumer consumer) {
-        if (!config.isEnabled() || config.isEventEnabled(eventType)) {
+        if (!config.isEnabled() || !config.shouldLogEvent(eventType)) {
             return;
         }
         


### PR DESCRIPTION
## Summary

- Rename `LoggingConfig.isEventEnabled()` to `shouldLogEvent()` with intuitive semantics (`enabled && enabledEvents.contains(eventType)`), matching `DiscordWebhookConfig`.
- Update `SpawnerActionLogger` guards to use the new method.

Replaces the closed #273 with a minimal, focused change.
