### PR TITLE
fix(gui): play open_sound when skip_main_gui opens storage directly

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/commands/list/gui/management/SpawnerManagementHandler.java
+++ b/core/src/main/java/github/nighter/smartspawner/commands/list/gui/management/SpawnerManagementHandler.java
@@ -90,8 +90,8 @@ public class SpawnerManagementHandler implements Listener {
             // Open storage GUI directly
             Inventory storageInventory = plugin.getSpawnerStorageUI()
                     .createStorageInventory(player, spawner, 1, -1);
-            player.playSound(player.getLocation(), Sound.BLOCK_CHEST_OPEN, 1.0f, 1.0f);
             player.openInventory(storageInventory);
+            plugin.getGuiButtonInteractionService().playOpenSound(player);
             return;
         }
 

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/layout/GuiButtonInteractionService.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/layout/GuiButtonInteractionService.java
@@ -114,6 +114,16 @@ public class GuiButtonInteractionService implements Listener {
         invalidSoundWarnings.clear();
     }
 
+    /**
+     * Plays the configured open_sound from main_gui.yml, if set.
+     */
+    public void playOpenSound(Player player) {
+        String openSound = plugin.getGuiLayoutConfig().getOpenSound();
+        if (openSound != null) {
+            playSound(player, new GuiButtonSoundData(openSound, 1.0f, 1.0f));
+        }
+    }
+
     private String formatRemainingTime(long remainingNanos) {
         long tenths = Math.max(1L, (remainingNanos + 99_999_999L) / 100_000_000L);
         if (tenths % 10L == 0L) {

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/main/SpawnerMenuUI.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/main/SpawnerMenuUI.java
@@ -174,14 +174,7 @@ public class SpawnerMenuUI {
         player.openInventory(menu);
 
         if (!refresh) {
-            String openSound = plugin.getGuiLayoutConfig().getOpenSound();
-            if (openSound != null) {
-                try {
-                    player.playSound(player.getLocation(), openSound, 1.0f, 1.0f);
-                } catch (Exception e) {
-                    plugin.getLogger().warning("Invalid open_sound in main_gui.yml: " + openSound);
-                }
-            }
+            plugin.getGuiButtonInteractionService().playOpenSound(player);
         }
 
         // Force timer update inactive for GUI if applicable

--- a/core/src/main/java/github/nighter/smartspawner/spawner/interactions/click/SpawnerClickManager.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/interactions/click/SpawnerClickManager.java
@@ -213,6 +213,7 @@ public class SpawnerClickManager implements Listener {
         Inventory storageInventory = plugin.getSpawnerStorageUI()
                 .createStorageInventory(player, spawner, 1, -1);
         player.openInventory(storageInventory);
+        plugin.getGuiButtonInteractionService().playOpenSound(player);
     }
 
     private boolean isSpawnEgg(Material material) {


### PR DESCRIPTION
## Summary
- Play the configured `open_sound` from `main_gui.yml` when `skip_main_gui` opens the storage GUI directly on spawner click.
- Centralize open-sound playback in `GuiButtonInteractionService.playOpenSound()` and reuse it from `SpawnerMenuUI`, `SpawnerClickManager`, and `SpawnerManagementHandler`.
- Replace the hardcoded chest sound in the admin spawner management path with the configured open sound.
