### PR TITLE
Fix Folia inventory close thread access

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageAction.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageAction.java
@@ -1,7 +1,6 @@
 package github.nighter.smartspawner.spawner.gui.storage;
 
 import github.nighter.smartspawner.SmartSpawner;
-import github.nighter.smartspawner.Scheduler;
 import github.nighter.smartspawner.api.events.SpawnerDropAllEvent;
 import github.nighter.smartspawner.api.events.SpawnerTakeAllEvent;
 import github.nighter.smartspawner.api.gui.GuiLayoutType;
@@ -895,19 +894,19 @@ public class SpawnerStorageAction implements Listener {
 
     @EventHandler
     public void onInventoryClose(InventoryCloseEvent event) {
-        if (!(event.getPlayer() instanceof Player player)) {
-            return;
-        }
-
         Inventory inventory = event.getInventory();
-        Scheduler.runEntityTask(player, () -> handleInventoryClose(inventory));
-    }
-
-    private void handleInventoryClose(Inventory inventory) {
         if (!(inventory.getHolder(false) instanceof StoragePageHolder holder)) {
             return;
         }
 
+        // Inventory close events already execute on the owning player's region thread.
+        // Do not defer this work to the player's scheduler: after closing, a block-backed
+        // inventory could belong to a different region and resolving its holder there
+        // violates Folia's thread ownership rules.
+        handleInventoryClose(holder);
+    }
+
+    private void handleInventoryClose(StoragePageHolder holder) {
         SpawnerData spawner = holder.getSpawnerData();
         if (spawner.isStorageDirty()){
             plugin.getSpawnerManager().markSpawnerModified(spawner.getSpawnerId());


### PR DESCRIPTION
## What changed

- Resolve the storage inventory holder directly during `InventoryCloseEvent`.
- Pass the resolved `StoragePageHolder` to close handling instead of scheduling another entity task.

## Why

On Folia/Canvas, the deferred entity task could execute in the player's current region while `Inventory#getHolder()` accessed a block-backed inventory owned by another region. Canvas rejected that cross-region world read with `Thread failed main thread check: Cannot read world asynchronously`.

## Impact

Closing inventories no longer causes SmartSpawner to perform an invalid cross-region holder lookup, while dirty storage state continues to be marked for persistence.

## Validation

- `./gradlew :core:compileJava`
- `git diff --check`