### PR TITLE
Track storage inventories across Folia regions

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageAction.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageAction.java
@@ -43,6 +43,7 @@ public class SpawnerStorageAction implements Listener {
     private final MessageService messageService;
     private final FilterConfigUI filterConfigUI;
     private final SpawnerManager spawnerManager;
+    private final SpawnerStorageUI spawnerStorageUI;
 
     private static final int INVENTORY_SIZE = 54;
     private static final int STORAGE_SLOTS = 45;
@@ -59,6 +60,7 @@ public class SpawnerStorageAction implements Listener {
         this.messageService = plugin.getMessageService();
         this.filterConfigUI = plugin.getFilterConfigUI();
         this.spawnerManager = plugin.getSpawnerManager();
+        this.spawnerStorageUI = plugin.getSpawnerStorageUI();
         loadConfig();
     }
 
@@ -69,8 +71,12 @@ public class SpawnerStorageAction implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onInventoryClick(InventoryClickEvent event) {
-        if (!(event.getWhoClicked() instanceof Player player) ||
-                !(event.getInventory().getHolder(false) instanceof StoragePageHolder holder)) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        StoragePageHolder holder = spawnerStorageUI.getStorageHolder(event.getInventory());
+        if (holder == null) {
             return;
         }
 
@@ -252,7 +258,7 @@ public class SpawnerStorageAction implements Listener {
         boolean collected = plugin.getSpawnerMenuAction().tryCollectExpForPlayer(player, spawner);
         if (collected) {
             // Refresh button display so the XP counter updates to 0
-            StoragePageHolder holder = (StoragePageHolder) inventory.getHolder(false);
+            StoragePageHolder holder = spawnerStorageUI.getStorageHolder(inventory);
             if (holder != null) {
                 plugin.getSpawnerStorageUI().updateDisplay(inventory, spawner, holder.getCurrentPage(), holder.getTotalPages());
             }
@@ -434,7 +440,7 @@ public class SpawnerStorageAction implements Listener {
     }
 
     private boolean handleDropPageItems(Player player, SpawnerData spawner, Inventory inventory) {
-        StoragePageHolder holder = (StoragePageHolder) inventory.getHolder(false);
+        StoragePageHolder holder = spawnerStorageUI.getStorageHolder(inventory);
         if (holder == null) {
             return false;
         }
@@ -546,11 +552,13 @@ public class SpawnerStorageAction implements Listener {
 
     private void updatePageContent(Player player, SpawnerData spawner, int newPage, Inventory inventory) {
         SpawnerStorageUI spawnerStorageUI = plugin.getSpawnerStorageUI();
-        StoragePageHolder holder = (StoragePageHolder) inventory.getHolder(false);
+        StoragePageHolder holder = spawnerStorageUI.getStorageHolder(inventory);
+        if (holder == null) {
+            return;
+        }
 
         int totalPages = calculateTotalPages(spawner);
 
-        assert holder != null;
         holder.setTotalPages(totalPages);
         holder.setCurrentPage(newPage);
         holder.updateOldUsedSlots();
@@ -680,7 +688,7 @@ public class SpawnerStorageAction implements Listener {
         spawner.getVirtualInventory().sortItems(nextSort);
 
         // Update GUI display to reflect VirtualInventory state
-        StoragePageHolder holder = (StoragePageHolder) inventory.getHolder(false);
+        StoragePageHolder holder = spawnerStorageUI.getStorageHolder(inventory);
         if (holder != null) {
             updatePageContent(player, spawner, holder.getCurrentPage(), inventory);
         }
@@ -719,7 +727,10 @@ public class SpawnerStorageAction implements Listener {
     }
 
     public boolean handleTakeAllItems(Player player, Inventory sourceInventory) {
-        StoragePageHolder holder = (StoragePageHolder) sourceInventory.getHolder(false);
+        StoragePageHolder holder = spawnerStorageUI.getStorageHolder(sourceInventory);
+        if (holder == null) {
+            return false;
+        }
         SpawnerData spawner = holder.getSpawnerData();
         VirtualInventory virtualInv = spawner.getVirtualInventory();
 
@@ -745,7 +756,7 @@ public class SpawnerStorageAction implements Listener {
         }
 
         // Transfer items and update VirtualInventory
-        TransferResult result = transferItems(player, sourceInventory, sourceItems, virtualInv);
+        TransferResult result = transferItems(player, sourceInventory, sourceItems, virtualInv, holder);
         sendTransferMessage(player, result);
         player.updateInventory();
 
@@ -803,7 +814,8 @@ public class SpawnerStorageAction implements Listener {
     }
 
     private TransferResult transferItems(Player player, Inventory sourceInventory,
-                                         Map<Integer, ItemStack> sourceItems, VirtualInventory virtualInv) {
+                                         Map<Integer, ItemStack> sourceItems, VirtualInventory virtualInv,
+                                         StoragePageHolder holder) {
         boolean anyItemMoved = false;
         boolean inventoryFull = false;
         PlayerInventory playerInv = player.getInventory();
@@ -864,7 +876,6 @@ public class SpawnerStorageAction implements Listener {
 
         // Update VirtualInventory
         if (!itemsToRemove.isEmpty()) {
-            StoragePageHolder holder = (StoragePageHolder) sourceInventory.getHolder(false);
             SpawnerData spawnerData = holder.getSpawnerData();
 
             spawnerData.removeItemsAndUpdateSellValue(itemsToRemove);
@@ -886,7 +897,7 @@ public class SpawnerStorageAction implements Listener {
 
     @EventHandler
     public void onInventoryDrag(InventoryDragEvent event) {
-        if (!(event.getInventory().getHolder(false) instanceof StoragePageHolder)) {
+        if (spawnerStorageUI.getStorageHolder(event.getInventory()) == null) {
             return;
         }
         event.setCancelled(true);
@@ -895,14 +906,11 @@ public class SpawnerStorageAction implements Listener {
     @EventHandler
     public void onInventoryClose(InventoryCloseEvent event) {
         Inventory inventory = event.getInventory();
-        if (!(inventory.getHolder(false) instanceof StoragePageHolder holder)) {
+        StoragePageHolder holder = spawnerStorageUI.unregisterStorageInventory(inventory);
+        if (holder == null) {
             return;
         }
 
-        // Inventory close events already execute on the owning player's region thread.
-        // Do not defer this work to the player's scheduler: after closing, a block-backed
-        // inventory could belong to a different region and resolving its holder there
-        // violates Folia's thread ownership rules.
         handleInventoryClose(holder);
     }
 

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageUI.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageUI.java
@@ -38,6 +38,7 @@ public class SpawnerStorageUI {
 
     // Precomputed buttons to avoid repeated creation
     private final Map<String, ItemStack> staticButtons;
+    private final Map<Inventory, StoragePageHolder> storageInventories;
 
     // Lightweight caches with better eviction strategies
     private final Map<String, ItemStack> navigationButtonCache;
@@ -59,6 +60,7 @@ public class SpawnerStorageUI {
 
         // Initialize caches with appropriate initial capacity
         this.staticButtons = new ConcurrentHashMap<>(16);
+        this.storageInventories = Collections.synchronizedMap(new IdentityHashMap<>());
         this.navigationButtonCache = new ConcurrentHashMap<>(16);
         this.pageIndicatorCache = new ConcurrentHashMap<>(16);
 
@@ -209,15 +211,36 @@ public class SpawnerStorageUI {
         GuiLayout layout = layoutConfig.getStorageLayout(spawner, player);
 
         // Create inventory with title including page info using placeholder-based format
+        StoragePageHolder holder = new StoragePageHolder(spawner, page, totalPages, layout);
         Inventory pageInv = Bukkit.createInventory(
-                new StoragePageHolder(spawner, page, totalPages, layout),
+                holder,
                 INVENTORY_SIZE,
                 getStorageTitle(spawner, page, totalPages)
         );
+        storageInventories.put(pageInv, holder);
 
-        // Populate the inventory
-        updateDisplay(pageInv, spawner, page, totalPages);
+        // Populate the inventory. If construction fails, do not retain a
+        // registry entry for an inventory that will never be opened.
+        try {
+            updateDisplay(pageInv, spawner, page, totalPages);
+        } catch (RuntimeException | Error failure) {
+            storageInventories.remove(pageInv);
+            throw failure;
+        }
         return pageInv;
+    }
+
+    /**
+     * Resolves holders only for virtual storage inventories created by this UI.
+     * This deliberately avoids Inventory#getHolder(), which may access a block
+     * inventory in a region not owned by the current Folia thread.
+     */
+    public StoragePageHolder getStorageHolder(Inventory inventory) {
+        return storageInventories.get(inventory);
+    }
+
+    public StoragePageHolder unregisterStorageInventory(Inventory inventory) {
+        return storageInventories.remove(inventory);
     }
 
     public void updateDisplay(Inventory inventory, SpawnerData spawner, int page, int totalPages) {
@@ -242,8 +265,11 @@ public class SpawnerStorageUI {
         }
 
         // Also mark all button slots for potential clearing (fixes visual bug where buttons remain when they shouldn't)
-        StoragePageHolder holder = (StoragePageHolder) inventory.getHolder(false);
-        assert holder != null;
+        StoragePageHolder holder = getStorageHolder(inventory);
+        if (holder == null) {
+            spawner.getInventoryLock().unlock();
+            return;
+        }
         GuiLayout layout = holder.getLayout();
         if (layout != null) {
             slotsToEmpty.addAll(layout.getUsedSlots());

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/synchronization/SpawnerGuiViewManager.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/synchronization/SpawnerGuiViewManager.java
@@ -13,7 +13,6 @@ import github.nighter.smartspawner.spawner.gui.synchronization.services.StorageU
 import github.nighter.smartspawner.spawner.gui.synchronization.services.TimerUpdateService;
 import github.nighter.smartspawner.spawner.properties.SpawnerData;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 
@@ -204,36 +203,39 @@ public class SpawnerGuiViewManager {
                 continue;
             }
 
-            // Schedule batched GUI update for main menu viewers
-            guiUpdateService.scheduleUpdate(viewerId, GuiUpdateService.UPDATE_ALL);
-
-            // Handle storage page updates - calculate pages on the correct thread
-            Inventory openInv = viewer.getOpenInventory().getTopInventory();
-            if (openInv.getHolder(false) instanceof StoragePageHolder holder) {
-                // Schedule storage update - page calculation happens inside
-                Location loc = viewer.getLocation();
-
-                if (!holder.getSpawnerData().getSpawnerId().equals(spawner.getSpawnerId())) {
-                    continue;
-                }
-                Scheduler.runLocationTask(loc, () -> {
-                    if (!viewer.isOnline()) {
-                        return;
-                    }
-
-                    Inventory inv = viewer.getOpenInventory().getTopInventory();
-                    if (inv.getHolder(false) instanceof StoragePageHolder spHolder) {
-
-                        if (!spHolder.getSpawnerData().getSpawnerId().equals(spawner.getSpawnerId())) {
-                            return;
-                        }
-                        int oldPages = storageUpdateService.calculateTotalPages(holder.getOldUsedSlots());
-                        int newPages = storageUpdateService.calculateTotalPages(spawner.getVirtualInventory().getUsedSlots());
-
-                        storageUpdateService.processStorageUpdateDirect(viewer, inv, spawner, spHolder, oldPages, newPages);
-                    }
-                });
+            ViewerTrackingManager.ViewerInfo viewerInfo = viewerTrackingManager.getViewerInfo(viewerId);
+            if (viewerInfo == null) {
+                continue;
             }
+
+            if (viewerInfo.getViewerType() == ViewerTrackingManager.ViewerType.MAIN_MENU) {
+                guiUpdateService.scheduleUpdate(viewerId, GuiUpdateService.UPDATE_ALL);
+                continue;
+            }
+            if (viewerInfo.getViewerType() != ViewerTrackingManager.ViewerType.STORAGE) {
+                continue;
+            }
+
+            // Entity schedulers follow players across region changes. Resolve the
+            // inventory only after the task owns the player, then use our registry
+            // rather than querying a potentially block-backed inventory holder.
+            Scheduler.runEntityTask(viewer, () -> {
+                if (!viewer.isOnline()) {
+                    return;
+                }
+
+                Inventory inv = viewer.getOpenInventory().getTopInventory();
+                StoragePageHolder holder = plugin.getSpawnerStorageUI().getStorageHolder(inv);
+                if (holder == null ||
+                        !holder.getSpawnerData().getSpawnerId().equals(spawner.getSpawnerId())) {
+                    return;
+                }
+
+                int oldPages = storageUpdateService.calculateTotalPages(holder.getOldUsedSlots());
+                int newPages = storageUpdateService.calculateTotalPages(spawner.getVirtualInventory().getUsedSlots());
+                storageUpdateService.processStorageUpdateDirect(
+                        viewer, inv, spawner, holder, oldPages, newPages);
+            });
         }
     }
 

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/synchronization/services/StorageUpdateService.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/synchronization/services/StorageUpdateService.java
@@ -6,7 +6,6 @@ import github.nighter.smartspawner.language.LanguageManager;
 import github.nighter.smartspawner.spawner.gui.storage.SpawnerStorageUI;
 import github.nighter.smartspawner.spawner.gui.storage.StoragePageHolder;
 import github.nighter.smartspawner.spawner.properties.SpawnerData;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 
@@ -58,22 +57,19 @@ public class StorageUpdateService {
      * @param newTotalPages New total pages
      */
     public void processStorageUpdate(Player viewer, SpawnerData spawner, int oldTotalPages, int newTotalPages) {
-        Location loc = viewer.getLocation();
-        if (loc != null) {
-            Scheduler.runLocationTask(loc, () -> {
-                if (!viewer.isOnline()) {
-                    return;
-                }
+        Scheduler.runEntityTask(viewer, () -> {
+            if (!viewer.isOnline()) {
+                return;
+            }
 
-                Inventory openInv = viewer.getOpenInventory().getTopInventory();
-                if (openInv == null || !(openInv.getHolder(false) instanceof StoragePageHolder)) {
-                    return;
-                }
+            Inventory openInv = viewer.getOpenInventory().getTopInventory();
+            StoragePageHolder holder = spawnerStorageUI.getStorageHolder(openInv);
+            if (holder == null) {
+                return;
+            }
 
-                StoragePageHolder holder = (StoragePageHolder) openInv.getHolder(false);
-                processStorageUpdateDirect(viewer, openInv, spawner, holder, oldTotalPages, newTotalPages);
-            });
-        }
+            processStorageUpdateDirect(viewer, openInv, spawner, holder, oldTotalPages, newTotalPages);
+        });
     }
 
     /**


### PR DESCRIPTION
## What changed

- Track SmartSpawner storage inventories by object identity in a synchronized registry.
- Resolve storage sessions from that registry in click, drag, close, transfer, and display paths instead of probing arbitrary inventories with `Inventory#getHolder()`.
- Remove registry entries when the corresponding inventory closes.
- Schedule player GUI updates with the entity scheduler so they follow players across Folia region changes.
- Only enqueue main-menu refreshes for viewers actually tracked as main-menu viewers.

## Root cause

The listener used `getHolder(false)` to determine whether every incoming inventory belonged to SmartSpawner. On modern versions, a player can retain a block inventory across a teleport. The player thread can therefore own region B while the block-backed inventory still belongs to region A, and merely resolving its holder performs a forbidden cross-region block-state read.

Moving holder resolution into `InventoryCloseEvent` is not sufficient because the close itself may happen after the region change. Thread checks also require a safely known location first. Tracking only the virtual inventories SmartSpawner creates avoids touching unrelated block inventories entirely. Entity scheduling remains appropriate for operations that target the player because it follows the entity across regions.

## Impact

SmartSpawner no longer probes arbitrary chest or block inventories from its storage listeners, and storage viewer updates remain valid when players change Folia regions. This follows up on #292.

## Validation

- `./gradlew :core:compileJava`
- `git diff --check`