### PR TITLE
Fix GUI slot duplication and empty sell navigation

### DIFF
--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/main/SpawnerMenuAction.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/main/SpawnerMenuAction.java
@@ -172,7 +172,12 @@ public class SpawnerMenuAction implements Listener {
                 }
                 // If no items to sell, still allow exp collection
                 if (spawner.getVirtualInventory().getUsedSlots() == 0) {
-                    boolean success = handleExpBottleAcceptedClick(player, spawner, true);
+                    boolean success = false;
+                    if (spawner.getSpawnerExp() > 0) {
+                        success = tryCollectExpForPlayer(player, spawner);
+                    } else {
+                        messageService.sendMessage(player, "spawner_storage_empty");
+                    }
                     playActionResult(player, button, clickType, success);
                     return true;
                 }

--- a/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageAction.java
+++ b/core/src/main/java/github/nighter/smartspawner/spawner/gui/storage/SpawnerStorageAction.java
@@ -227,10 +227,10 @@ public class SpawnerStorageAction implements Listener {
 
         // Check if there are items to sell
         if (spawner.getVirtualInventory().getUsedSlots() == 0) {
-            if (collectExp) {
-                // No items to sell but still collect exp
+            if (collectExp && spawner.getSpawnerExp() > 0) {
+                // No items to sell, but collect available exp without leaving the storage GUI
                 boolean success = plugin.getSpawnerMenuAction()
-                        .handleExpBottleAcceptedClick(player, spawner, true);
+                        .tryCollectExpForPlayer(player, spawner);
                 playActionResult(player, sourceButton, sourceClickType, success);
             } else {
                 messageService.sendMessage(player, "spawner_storage_empty");

--- a/core/src/main/java/github/nighter/smartspawner/updates/GuiLayoutUpdater.java
+++ b/core/src/main/java/github/nighter/smartspawner/updates/GuiLayoutUpdater.java
@@ -39,6 +39,9 @@ public class GuiLayoutUpdater {
                         plugin.getResource(resource),
                         java.util.List.of(),
                         ConfigMigrations.GUI_LAYOUT,
+                        true,
+                        YamlMigrator.OwnedSection.fullyUserManaged(
+                                (defaults, path) -> !path.contains(".") && path.startsWith("slot_")),
                         plugin.getLogger());
             }
         }

--- a/core/src/main/java/github/nighter/smartspawner/updates/YamlMigrator.java
+++ b/core/src/main/java/github/nighter/smartspawner/updates/YamlMigrator.java
@@ -71,18 +71,22 @@ public final class YamlMigrator {
      * children back would resurrect deleted drops, or put a chat line back under a message the
      * owner turned into an action bar.</p>
      *
-     * <p>Either way, once the user has the section its contents are left alone. The two factories
+     * <p>Either way, once the user has the section its contents are left alone. The factories
      * differ only in what an <em>absent</em> section means, which is not the same question for a
-     * drop list as for a message.</p>
+     * drop list, a message, or a fully user-managed GUI button list.</p>
      */
-    public record OwnedSection(SectionMatcher matcher, boolean keepDeleted) {
+    public record OwnedSection(SectionMatcher matcher, boolean keepDeleted, boolean alwaysLocked) {
+
+        public OwnedSection(SectionMatcher matcher, boolean keepDeleted) {
+            this(matcher, keepDeleted, false);
+        }
 
         /**
          * For a list the user curates. A section they removed entirely stays removed, as long as
          * they still have its parent. Deleting a mob's whole {@code loot} block has to stick.
          */
         public static OwnedSection curated(SectionMatcher matcher) {
-            return new OwnedSection(matcher, true);
+            return new OwnedSection(matcher, true, false);
         }
 
         /**
@@ -92,7 +96,15 @@ public final class YamlMigrator {
          * theirs; only a wholly absent message is refilled.
          */
         public static OwnedSection restoredWhenAbsent(SectionMatcher matcher) {
-            return new OwnedSection(matcher, false);
+            return new OwnedSection(matcher, false, false);
+        }
+
+        /**
+         * For sections whose presence and contents are both controlled by the user. Matching
+         * default sections are never topped up, even when the user removed or relocated them.
+         */
+        public static OwnedSection fullyUserManaged(SectionMatcher matcher) {
+            return new OwnedSection(matcher, true, true);
         }
     }
 
@@ -247,14 +259,19 @@ public final class YamlMigrator {
      * leaf of a brand new section create that section, after which every remaining leaf of it looks
      * user-owned and gets skipped, leaving the section half filled.</p>
      *
-     * <p>A section the user has is always owned. A section they do not have is owned only for a
-     * {@link OwnedSection#curated} marker, and then only when they still have its parent, which is
-     * what tells a block they deleted apart from one they have never seen.</p>
+     * <p>A section the user has is always owned. A fully user-managed section is also owned when
+     * absent. Other absent sections are owned only for a {@link OwnedSection#curated} marker, and
+     * then only when they still have its parent, which tells a block they deleted apart from one
+     * they have never seen.</p>
      */
     private static Set<String> lockedSections(YamlConfiguration user, YamlConfiguration defaults, OwnedSection owned) {
         Set<String> locked = new HashSet<>();
         for (String path : defaults.getKeys(true)) {
             if (!defaults.isConfigurationSection(path) || !owned.matcher().matches(defaults, path)) continue;
+            if (owned.alwaysLocked()) {
+                locked.add(path);
+                continue;
+            }
             if (user.isConfigurationSection(path)) {
                 locked.add(path);
                 continue;


### PR DESCRIPTION
## Summary

- preserve user-managed `slot_*` sections when GUI layout files are migrated
- keep top-level GUI settings eligible for automatic config updates
- collect available XP without navigating away when `sell_and_exp` has no items to sell
- show the storage-empty failure state without reopening the main GUI when both storage and XP are empty

## Root cause

The version-less YAML migrator treated missing slot paths as missing defaults. Moving or deleting a configured button therefore caused its original default slot to be restored on reload.

The empty `sell_and_exp` path also called a legacy XP helper that always reopened the main GUI, including when there was no XP to collect.

## Impact

Server owners can move or remove GUI buttons without the updater duplicating them. Players using layouts such as DonutSMP_v2 remain in the current GUI when an empty sell action fails or only collects XP.

## Validation

- `./gradlew build`
- `git diff --check`

Closes #301
